### PR TITLE
v0.5.0: Ported to offset ptrs for relocatable storage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,10 @@
 variables:
+  GIT_SUBMODULE_STRATEGY: recursive
   pacman_deps: cmake ninja gcc yaml-cpp
   pacman_deps_makepkg: rsync fakeroot git namcap
   pacman_deps_py: python python-pip
   pacman_deps_test: gtest gcovr
-  pacman_deps_pytest: python-pytest python-numpy nanobind
+  pacman_deps_pytest: python-pytest python-numpy
   pacman_deps_clang: clang
 
 stages:
@@ -16,6 +17,9 @@ stages:
 .aarch64:
   image: lopsided/archlinux-arm64v8:latest
   tags: [aarch64]
+.build_tests_only:
+  before_script:
+    - rm -rf cmake ext src
 
 test_devel_coverage-amd64:
   extends: [.test_devel_coverage, .amd64]
@@ -99,6 +103,7 @@ test_archlinux_cpp-aarch64:
   needs: [build_archlinux-aarch64]
 .test_archlinux_cpp:
   stage: test
+  extends: [.build_tests_only]
   script:
     - pacman -Syu --noconfirm --needed ${pacman_deps} ${pacman_deps_test}
     - pacman -U --noconfirm ./structstore-*.pkg.tar.zst
@@ -109,12 +114,12 @@ test_archlinux_cpp-aarch64:
 test_archlinux_py-amd64:
   extends: [.test_archlinux_py, .amd64]
   needs: [build_archlinux-amd64]
-  allow_failure: true  # lapack 3.12.1-1 causes an undefined symbol error
 test_archlinux_py-aarch64:
   extends: [.test_archlinux_py, .aarch64]
   needs: [build_archlinux-aarch64]
 .test_archlinux_py:
   stage: test
+  extends: [.build_tests_only]
   script:
     - pacman -Syu --noconfirm --needed ${pacman_deps} ${pacman_deps_py} ${pacman_deps_test} ${pacman_deps_pytest}
     - pacman -U --noconfirm ./structstore{,_py}-*.pkg.tar.zst
@@ -147,6 +152,7 @@ test_py_tarball-aarch64:
   needs: [build_pyproj-aarch64]
 .test_py_tarball:
   stage: test
+  extends: [.build_tests_only]
   script:
     - pacman -Syu --noconfirm --needed ${pacman_deps} ${pacman_deps_py} ${pacman_deps_test}
     - chmod a+rX -R .
@@ -161,6 +167,7 @@ test_py_wheel-aarch64:
   needs: [build_pyproj-aarch64]
 .test_py_wheel:
   stage: test
+  extends: [.build_tests_only]
   script:
     - pacman -Syu --noconfirm --needed ${pacman_deps} ${pacman_deps_py} ${pacman_deps_test}
     - chmod a+rX -R .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,6 +109,7 @@ test_archlinux_cpp-aarch64:
 test_archlinux_py-amd64:
   extends: [.test_archlinux_py, .amd64]
   needs: [build_archlinux-amd64]
+  allow_failure: true  # lapack 3.12.1-1 causes an undefined symbol error
 test_archlinux_py-aarch64:
   extends: [.test_archlinux_py, .aarch64]
   needs: [build_archlinux-aarch64]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,21 @@ test_devel_sanitize-aarch64:
     - su nobody -s /bin/bash -c "cmake --build build"
     - su nobody -s /bin/bash -c "./scripts/devel_test.sh"
 
+test_devel_release-amd64:
+  extends: [.test_devel_release, .amd64]
+test_devel_release-aarch64:
+  extends: [.test_devel_release, .aarch64]
+.test_devel_release:
+  stage: test
+  needs: []
+  script:
+    - pacman -Syu --noconfirm --needed ${pacman_deps} ${pacman_deps_py} ${pacman_deps_test}
+    - chmod a+rX -R .
+    - usermod -e -1 nobody
+    - su nobody -s /bin/bash -c "BUILD_RELEASE=ON ./scripts/devel_setup.sh"
+    - su nobody -s /bin/bash -c "cmake --build build"
+    - su nobody -s /bin/bash -c "./scripts/devel_test.sh"
+
 test_devel_clang-amd64:
   extends: [.test_devel_clang, .amd64]
 test_devel_clang-aarch64:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/nanobind"]
+	path = ext/nanobind
+	url = https://github.com/wjakob/nanobind

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ext/nanobind"]
 	path = ext/nanobind
 	url = https://github.com/wjakob/nanobind
+[submodule "ext/ankerl_unordered_dense"]
+	path = ext/ankerl_unordered_dense
+	url = https://github.com/martinus/unordered_dense

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ if(${BUILD_WITH_PYTHON})
             DESTINATION ${STRUCTSTORE_INSTALL_LIBDIR_PY})
 
     if(NOT ${BUILD_WITH_SANITIZER})
-        nanobind_stubgen_install(structstore_py ${STRUCTSTORE_INSTALL_LIBDIR_PY})
+        # nanobind_stubgen_install(structstore_py ${STRUCTSTORE_INSTALL_LIBDIR_PY})
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
+cmake_policy(VERSION 3.24)
 project(structstore VERSION 0.4.0)
 
 # build options
@@ -16,6 +17,7 @@ option(BUILD_WITH_SANITIZER
 
 if(${BUILD_WITH_PYTHON})
     message(STATUS "Building with Python bindings")
+    find_package(Python 3.10 COMPONENTS Interpreter Development REQUIRED)
 endif()
 if(${BUILD_WITH_PY_BUILD_CMAKE})
     message(STATUS "Building with py-build-cmake")
@@ -35,22 +37,22 @@ if(${BUILD_WITH_PY_BUILD_CMAKE})
     endif()
 endif()
 
+# for cmake includes
+set(STRUCTSTORE_CMAKE_DIR ${PROJECT_SOURCE_DIR}/cmake)
+# for 'ext' libs
+set(STRUCTSTORE_LIB_DIR ${PROJECT_SOURCE_DIR})
+
 # dependencies
 
 include(CheckCCompilerFlag)
 include(GenerateExportHeader)
 include(GNUInstallDirs)
+include(FetchContent)
 
 find_package(yaml-cpp REQUIRED)
 
 if(${BUILD_WITH_PYTHON})
-    find_package(Python 3.10 COMPONENTS Interpreter Development REQUIRED)
-    execute_process(
-            COMMAND "${Python_EXECUTABLE}" -c "import nanobind; print(nanobind.cmake_dir())"
-            OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE NB_DIR)
-    list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
-    find_package(nanobind CONFIG REQUIRED)
-    include(cmake/NanobindStubgen.cmake)
+    include(${PROJECT_SOURCE_DIR}/cmake/StructStoreBindings.cmake)
 endif()
 
 # source files
@@ -110,8 +112,6 @@ if(${BUILD_WITH_PYTHON})
 
     # targets that will not be linked against: default python bindings
 
-    include(cmake/StructStoreBindings.cmake)
-
     add_structstore_binding(structstore_py src/structstore_py.cpp)
     list(APPEND STRUCTSTORE_PY_TARGETS structstore_py)
 
@@ -160,6 +160,7 @@ set(STRUCTSTORE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
 set(STRUCTSTORE_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/structstore)
 set(STRUCTSTORE_INSTALL_LICENSEDIR ${CMAKE_INSTALL_DATADIR}/licenses/structstore)
 set(STRUCTSTORE_INSTALL_LICENSEDIR_PY ${CMAKE_INSTALL_DATADIR}/licenses/structstore_py)
+set(STRUCTSTORE_CMAKE_TO_LIB_DIR ../../structstore)
 
 if(${BUILD_WITH_PYTHON})
     set_target_properties(structstore_py PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${STRUCTSTORE_INSTALL_LIBDIR})
@@ -172,7 +173,8 @@ if(${BUILD_WITH_PY_BUILD_CMAKE})
     set(STRUCTSTORE_INSTALL_CMAKEDIR ${PY_BUILD_CMAKE_MODULE_NAME}/cmake)
     set(STRUCTSTORE_INSTALL_LICENSEDIR ${PY_BUILD_CMAKE_MODULE_NAME})
     set(STRUCTSTORE_INSTALL_LICENSEDIR_PY ${PY_BUILD_CMAKE_MODULE_NAME})
-    set_target_properties(structstore_py PROPERTIES INSTALL_RPATH "\\\$ORIGIN")
+    set(STRUCTSTORE_CMAKE_TO_LIB_DIR ..)
+    set_target_properties(structstore_py PROPERTIES INSTALL_RPATH "\$ORIGIN")
 endif()
 
 install(TARGETS structstore_lib
@@ -182,6 +184,9 @@ install(TARGETS structstore_lib
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/include/structstore
         COMPONENT base
         DESTINATION ${STRUCTSTORE_INSTALL_INCLUDEDIR})
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/ext
+        COMPONENT base
+        DESTINATION ${STRUCTSTORE_INSTALL_LIBDIR})
 
 if(${BUILD_WITH_PYTHON})
     install(TARGETS structstore_py_lib
@@ -227,6 +232,14 @@ install(FILES
 
 if(${BUILD_WITH_PYTHON})
     export(PACKAGE StructStorePy)
+    install(FILES
+            "${PROJECT_SOURCE_DIR}/cmake/NanobindStubgen.cmake"
+            COMPONENT python
+            DESTINATION ${STRUCTSTORE_INSTALL_CMAKEDIR})
+    install(FILES
+            "${PROJECT_SOURCE_DIR}/cmake/StructStoreBindings.cmake"
+            COMPONENT python
+            DESTINATION ${STRUCTSTORE_INSTALL_CMAKEDIR})
     configure_file(${PROJECT_SOURCE_DIR}/cmake/StructStorePyConfig.cmake.in
             "${PROJECT_BINARY_DIR}/StructStorePyConfig.cmake" @ONLY)
     install(FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,10 @@ foreach(TARGET ${STRUCTSTORE_LIB_TARGETS} ${STRUCTSTORE_PY_TARGETS})
             PUBLIC
             "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/include>"
             "$<INSTALL_INTERFACE:${STRUCTSTORE_INSTALL_INCLUDEDIR}>")
+    target_include_directories(${TARGET}
+            SYSTEM PUBLIC
+            "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ext/ankerl_unordered_dense/include>"
+            "$<INSTALL_INTERFACE:${STRUCTSTORE_INSTALL_LIBDIR}/ext/ankerl_unordered_dense/include>")
 endforeach()
 
 # inspired by https://stackoverflow.com/a/49857699

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 cmake_policy(VERSION 3.24)
-project(structstore VERSION 0.4.0)
+project(structstore VERSION 0.5.0)
 
 # build options
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=structstore
 pkgname=(structstore structstore_py)
-pkgver=0.4.0
+pkgver=0.5.0
 pkgrel=1
 pkgdesc='Structured object storage, dynamically typed, to be shared between processes'
 arch=('x86_64' 'aarch64')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -49,7 +49,8 @@ package_structstore() {
     DESTDIR="$pkgdir" cmake --install build
 
     # keep only non-Python files
-    find "$pkgdir" -type f | sed "s@$pkgdir@@" | grep -i py \
+    find "$pkgdir" -type f | sed "s@$pkgdir@@" \
+        | grep -i -e py -e nanobind -e binding \
         | while IFS='' read f; do rm "$pkgdir/$f"; done
     find "$pkgdir" -type d -empty -delete
 }
@@ -63,7 +64,8 @@ package_structstore_py() {
     DESTDIR="$pkgdir" cmake --install build
 
     # keep only Python files
-    find "$pkgdir" -type f | sed "s@$pkgdir@@" | grep -i -v py \
+    find "$pkgdir" -type f | sed "s@$pkgdir@@" \
+        | grep -i -v -e py -e nanobind -e binding \
         | while IFS='' read f; do rm "$pkgdir/$f"; done
     find "$pkgdir" -type d -empty -delete
 }

--- a/cmake/StructStoreBindings.cmake
+++ b/cmake/StructStoreBindings.cmake
@@ -27,6 +27,6 @@ function(add_structstore_binding binding_target binding_srcs)
     target_include_directories(${binding_target} SYSTEM PRIVATE ${NB_INC_DIRS})
 
     if(NOT ${BUILD_WITH_SANITIZER})
-        nanobind_stubgen(${binding_target})
+        # nanobind_stubgen(${binding_target})
     endif()
 endfunction()

--- a/cmake/StructStoreBindings.cmake
+++ b/cmake/StructStoreBindings.cmake
@@ -1,3 +1,10 @@
+FetchContent_Declare(nanobind
+    URL ${STRUCTSTORE_LIB_DIR}/ext/nanobind
+    SYSTEM)
+FetchContent_MakeAvailable(nanobind)
+
+include(${STRUCTSTORE_CMAKE_DIR}/NanobindStubgen.cmake)
+
 function(add_structstore_binding binding_target binding_srcs)
     nanobind_add_module(${binding_target} ${binding_srcs} NB_STATIC)
     target_link_libraries(${binding_target} PUBLIC structstore_py_lib)

--- a/cmake/StructStoreConfig.cmake.in
+++ b/cmake/StructStoreConfig.cmake.in
@@ -2,5 +2,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(yaml-cpp REQUIRED)
 
 get_filename_component(STRUCTSTORE_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(STRUCTSTORE_CMAKE_TO_LIB_DIR @STRUCTSTORE_CMAKE_TO_LIB_DIR@)
+set(STRUCTSTORE_LIB_DIR "${STRUCTSTORE_CMAKE_DIR}/${STRUCTSTORE_CMAKE_TO_LIB_DIR}")
 
 include("${STRUCTSTORE_CMAKE_DIR}/StructStoreTargets.cmake")

--- a/cmake/StructStorePyConfig.cmake.in
+++ b/cmake/StructStorePyConfig.cmake.in
@@ -1,6 +1,4 @@
 include(CMakeFindDependencyMacro)
 find_dependency(StructStore REQUIRED)
 
-get_filename_component(STRUCTSTORE_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-
 include("${STRUCTSTORE_CMAKE_DIR}/StructStorePyTargets.cmake")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,12 @@ authors = [{ 'name' = 'Max Mertens', 'email' = 'max.mail@dameweb.de' }]
 license = { 'file' = 'LICENSE' }
 readme = 'README.md'
 urls = { 'Homepage' = 'https://github.com/mertemba/structstore' }
-dependencies = ['nanobind']
+dependencies = []
 dynamic = ['version']
 
 [build-system]
 requires = [
     'py-build-cmake~=0.1.8',
-    'nanobind~=2.2.0',
     'nanobind-stubgen~=0.1.5',
 ]
 build-backend = 'py_build_cmake.build'
@@ -22,7 +21,7 @@ name = 'structstore'
 directory = 'src'
 
 [tool.py-build-cmake.sdist]
-include = ['CMakeLists.txt', 'cmake/*', 'src/include/structstore/*.hpp', 'src/*.cpp']
+include = ['CMakeLists.txt', 'cmake/*', 'src/include/structstore/*.hpp', 'src/*.cpp', 'ext/*']
 exclude = []
 
 [tool.py-build-cmake.cmake]
@@ -61,7 +60,6 @@ version = '0'
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 py-build-cmake = "^0.3.4"
-nanobind = "^2.4.0"
 nanobind-stubgen = "^0.1.5"
 numpy = "^2.2.0"
 build = "^1.2.2.post1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,9 +24,6 @@ lark==1.2.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80
 nanobind-stubgen==0.1.5 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:3f4e3c852dfb6ce2bd51fa5e710f3019180176669280fd00e7293e08dee76709
-nanobind==2.4.0 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:8cf27b04fbadeb9deb4a73f02bd838bf9f7e3e5a8ce44c50c93142b5728da58a \
-    --hash=sha256:a0392dee5f58881085b2ac8bfe8e53f74285aa4868b1472bfaf76cfb414e1c96
 numpy==2.2.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:059e6a747ae84fce488c3ee397cee7e5f905fd1bda5fb18c66bc41807ff119b2 \
     --hash=sha256:08ef779aed40dbc52729d6ffe7dd51df85796a702afbf68a4f4e41fafdc8bda5 \

--- a/scripts/build_config.sh
+++ b/scripts/build_config.sh
@@ -16,3 +16,8 @@ fi
 if [ ! -z "$BUILD_WITH_SANITIZER" ]; then
     cmake_options="$cmake_options -DBUILD_WITH_SANITIZER=ON"
 fi
+if [ ! -z "$BUILD_RELEASE" ]; then
+    cmake_options="$cmake_options -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+else
+    cmake_options="$cmake_options -DCMAKE_BUILD_TYPE=Debug"
+fi

--- a/scripts/devel_setup.sh
+++ b/scripts/devel_setup.sh
@@ -12,6 +12,6 @@ source "$srcdir/scripts/setup_venv.sh"
 ln -sf "$builddir/compile_commands.json" "$srcdir/"
 
 cmake -B "$builddir" -S "$srcdir" -G Ninja $cmake_options \
-    -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DBUILD_WITH_PYTHON=ON -DBUILD_WITH_TESTING=ON \
     -DCMAKE_COLOR_DIAGNOSTICS=ON -DCMAKE_INSTALL_PREFIX:PATH="build/venv"

--- a/scripts/devel_test.sh
+++ b/scripts/devel_test.sh
@@ -20,7 +20,7 @@ export PYTHONPATH="$PYTHONPATH:$builddir"
 
 # test
 ctest --test-dir build --output-on-failure
-timeout 5 pytest -vv "$srcdir/tests"
+timeout 5 pytest -vvs "$srcdir/tests"
 
 # coverage analysis
 gcovr --cobertura-pretty --exclude-unreachable-branches --print-summary \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,7 +18,7 @@ if [ ! -z "$BUILD_WITH_VENV" ]; then
     fi
 fi
 
-cmake "$srcdir/tests" -GNinja -DCMAKE_BUILD_TYPE=Debug $cmake_options
+cmake "$srcdir/tests" -GNinja $cmake_options
 ninja
 ctest --output-on-failure
 if [ ! -z "$BUILD_WITH_PYTHON" ]; then

--- a/src/include/structstore/mini_malloc.hpp
+++ b/src/include/structstore/mini_malloc.hpp
@@ -7,17 +7,17 @@ namespace structstore {
 
 struct mini_malloc;
 
-// this function must be called exactly once before the first call to mm_alloc or mm_free,
+// this function must be called exactly once before the first call to sh_alloc or mm_free,
 // with a block of memory and its size as parameters
-mini_malloc* init_mini_malloc(void* buffer, size_t blocksize);
+void init_mini_malloc(mini_malloc* sh_alloc, size_t blocksize);
 
 // returns a pointer to size bytes of memory, aligned to 8 bytes
-void* mm_allocate(mini_malloc*, size_t size);
+void* mm_allocate(mini_malloc* sh_alloc, size_t size);
 
-// free a block of memory previously allocated by mm_alloc
-void mm_free(mini_malloc*, void* ptr);
+// free a block of memory previously allocated by sh_alloc
+void mm_free(mini_malloc* sh_alloc, void* ptr);
 
-void mm_assert_all_freed(mini_malloc*);
+void mm_assert_all_freed(mini_malloc* sh_alloc);
 
 } // namespace structstore
 

--- a/src/include/structstore/mini_malloc.hpp
+++ b/src/include/structstore/mini_malloc.hpp
@@ -15,7 +15,7 @@ void init_mini_malloc(mini_malloc* sh_alloc, size_t blocksize);
 void* mm_allocate(mini_malloc* sh_alloc, size_t size);
 
 // free a block of memory previously allocated by sh_alloc
-void mm_free(mini_malloc* sh_alloc, void* ptr);
+void mm_free(mini_malloc* sh_alloc, const void* ptr);
 
 void mm_assert_all_freed(mini_malloc* sh_alloc);
 

--- a/src/include/structstore/structstore.hpp
+++ b/src/include/structstore/structstore.hpp
@@ -6,6 +6,7 @@
 #include "structstore/stst_field.hpp"
 #include "structstore/stst_fieldmap.hpp"
 #include "structstore/stst_lock.hpp"
+#include "structstore/stst_offsetptr.hpp"
 #include "structstore/stst_shared.hpp"
 #include "structstore/stst_struct.hpp"
 #include "structstore/stst_structstore.hpp"

--- a/src/include/structstore/stst_alloc.hpp
+++ b/src/include/structstore/stst_alloc.hpp
@@ -4,9 +4,11 @@
 #include "structstore/mini_malloc.hpp"
 #include "structstore/stst_callstack.hpp"
 #include "structstore/stst_lock.hpp"
+#include "structstore/stst_offsetptr.hpp"
 
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <cstring>
 #include <functional>
 #include <sstream>
@@ -17,51 +19,52 @@ namespace structstore {
 
 class StringStorage;
 
-class MiniMalloc {
+class SharedAlloc {
     using byte = uint8_t;
     static constexpr size_t ALIGN = 8;
 
     // member variables
-    mini_malloc* mm;
+    OffsetPtr<mini_malloc> mm;
     SpinMutex mutex;
-    byte* const buffer;
     const size_t blocksize;
-    StringStorage* string_storage;
+    OffsetPtr<StringStorage> string_storage;
 
 public:
-    MiniMalloc(void* buffer, size_t size);
+    SharedAlloc(void* buffer, size_t size);
 
-    ~MiniMalloc() noexcept(false);
+    ~SharedAlloc() noexcept(false);
 
-    MiniMalloc() = delete;
+    SharedAlloc() = delete;
 
-    MiniMalloc(MiniMalloc&&) = delete;
+    SharedAlloc(SharedAlloc&&) = delete;
 
-    MiniMalloc(const MiniMalloc&) = delete;
+    SharedAlloc(const SharedAlloc&) = delete;
 
-    MiniMalloc& operator=(MiniMalloc&&) = delete;
+    SharedAlloc& operator=(SharedAlloc&&) = delete;
 
-    MiniMalloc& operator=(const MiniMalloc&) = delete;
+    SharedAlloc& operator=(const SharedAlloc&) = delete;
 
     bool init() { return true; }
 
     void dispose() {}
 
-    void* allocate(size_t field_size) {
+    template<typename T = void>
+    T* allocate(size_t field_size = sizeof(T)) {
         if (field_size == 0) { field_size = ALIGN; }
         ScopedLock<true> lock{mutex};
-        void* ptr = mm_allocate(mm, field_size);
+        void* ptr = mm_allocate(mm.get(), field_size);
         if (ptr == nullptr) {
             std::ostringstream str;
-            str << "insufficient space in mm_alloc region, requested: " << field_size;
+            str << "insufficient space in sh_alloc region, requested: " << field_size;
             Callstack::throw_with_trace<std::runtime_error>(str.str());
         }
-        return ptr;
+        assert((uint64_t) ptr % ALIGN == 0);
+        return (T*) ptr;
     }
 
     void deallocate(void* ptr) {
         ScopedLock<true> lock{mutex};
-        mm_free(mm, ptr);
+        mm_free(mm.get(), ptr);
     }
 
     bool is_owned(const void* ptr) const {
@@ -71,7 +74,7 @@ public:
 #endif
             return false;
         }
-        if (ptr < buffer || ptr >= buffer + blocksize) {
+        if (ptr < (byte*) mm.get() || ptr >= (byte*) mm.get() + blocksize) {
 #ifndef NDEBUG
             Callstack::warn_with_trace("checked pointer is outside arena");
 #endif
@@ -80,29 +83,32 @@ public:
         return true;
     }
 
-    inline StringStorage& strings() { return *string_storage; }
+    inline StringStorage& strings() { return *string_storage.get(); }
 };
 
-extern MiniMalloc static_alloc;
+extern SharedAlloc static_alloc;
 
 template<typename T = char>
 class StlAllocator {
     template<typename U>
     friend class StlAllocator;
 
-    MiniMalloc& mm_alloc;
+    SharedAlloc& sh_alloc;
 
 public:
     using value_type = T;
+    using pointer = OffsetPtr<T>;
 
-    explicit StlAllocator(MiniMalloc& a) : mm_alloc(a) {}
+    explicit StlAllocator(SharedAlloc& a) : sh_alloc(a) {}
 
     template<typename U>
-    StlAllocator(const StlAllocator<U>& other) : mm_alloc(other.mm_alloc) {}
+    StlAllocator(const StlAllocator<U>& other) : sh_alloc(other.sh_alloc) {}
 
-    T* allocate(std::size_t n) { return static_cast<T*>(mm_alloc.allocate(n * sizeof(T))); }
+    T* allocate(std::size_t n) { return static_cast<T*>(sh_alloc.allocate(n * sizeof(T))); }
 
-    void deallocate(T* p, std::size_t) { mm_alloc.deallocate(p); }
+    void deallocate(T* p, std::size_t) { sh_alloc.deallocate(p); }
+
+    void deallocate(const OffsetPtr<T>& p, std::size_t) { sh_alloc.deallocate(p.get()); }
 
     // defined in stst_typing.hpp
     inline void construct(T* p);
@@ -119,15 +125,15 @@ public:
 
     template<typename U>
     bool operator==(StlAllocator<U> const& rhs) const {
-        return &mm_alloc == &rhs.mm_alloc;
+        return &sh_alloc == &rhs.sh_alloc;
     }
 
     template<typename U>
     bool operator!=(StlAllocator<U> const& rhs) const {
-        return &mm_alloc != &rhs.mm_alloc;
+        return &sh_alloc != &rhs.sh_alloc;
     }
 
-    MiniMalloc& get_alloc() { return mm_alloc; }
+    SharedAlloc& get_alloc() { return sh_alloc; }
 };
 
 using shr_string = std::basic_string<char, std::char_traits<char>, StlAllocator<char>>;
@@ -143,12 +149,12 @@ template<class T>
 using shr_unordered_set = std::unordered_set<T, std::hash<T>, std::equal_to<T>, StlAllocator<T>>;
 
 class StringStorage {
-    MiniMalloc& mm_alloc;
+    SharedAlloc& sh_alloc;
     shr_unordered_set<shr_string> data;
     SpinMutex mutex;
 
 public:
-    StringStorage(MiniMalloc& mm_alloc) : mm_alloc{mm_alloc}, data{StlAllocator<int>(mm_alloc)} {}
+    StringStorage(SharedAlloc& sh_alloc) : sh_alloc{sh_alloc}, data{StlAllocator<int>(sh_alloc)} {}
 
     const shr_string* internalize(const std::string& str);
 

--- a/src/include/structstore/stst_alloc.hpp
+++ b/src/include/structstore/stst_alloc.hpp
@@ -60,7 +60,7 @@ public:
         if (ptr == nullptr) {
             std::ostringstream str;
             str << "insufficient space in sh_alloc region, requested: " << field_size;
-            Callstack::throw_with_trace<std::runtime_error>(str.str());
+            Callstack::throw_with_trace(str.str());
         }
         assert((size_t) ptr % ALIGN == 0);
         STST_LOG_DEBUG() << "allocating " << typeid(T).name() << " at " << ptr;

--- a/src/include/structstore/stst_callstack.hpp
+++ b/src/include/structstore/stst_callstack.hpp
@@ -1,6 +1,7 @@
 #ifndef STST_CALLSTACK_HPP
 #define STST_CALLSTACK_HPP
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -18,7 +19,7 @@ public:
 
     std::string format_with_trace(const std::string& what);
 
-    template<typename T>
+    template<typename T = std::runtime_error>
     static void throw_with_trace(const std::string& what) {
         throw T(cur().format_with_trace(what));
     }

--- a/src/include/structstore/stst_containers.hpp
+++ b/src/include/structstore/stst_containers.hpp
@@ -28,7 +28,7 @@ public:
 // instances of this class reside in shared memory, thus no raw pointers
 // or references should be used; use structstore::OffsetPtr<T> instead.
 class List : public FieldType<List> {
-    OffsetPtr<SharedAlloc> sh_alloc;
+    OffsetPtr<SharedAlloc, int64_t> sh_alloc;
     shr_vector<Field> data;
 
 public:

--- a/src/include/structstore/stst_containers.hpp
+++ b/src/include/structstore/stst_containers.hpp
@@ -25,6 +25,13 @@ public:
     String& operator=(const std::string& value);
 };
 
+
+// do not use reference wrapper for String class
+template<>
+struct RefWrapper<String> {
+    using W = String&;
+};
+
 // instances of this class reside in shared memory, thus no raw pointers
 // or references should be used; use structstore::OffsetPtr<T> instead.
 class List : public FieldType<List> {

--- a/src/include/structstore/stst_containers.hpp
+++ b/src/include/structstore/stst_containers.hpp
@@ -62,10 +62,6 @@ public:
         Field& operator*() { return ((List&) list).data.at(index); }
     };
 
-    List() : mm_alloc(static_alloc), data(StlAllocator<Field>(static_alloc)) {
-        throw std::runtime_error("List should not be constructed without an allocator");
-    }
-
     explicit List(MiniMalloc& mm_alloc) : mm_alloc(mm_alloc), data(StlAllocator<Field>(mm_alloc)) {
         STST_LOG_DEBUG() << "constructing List at " << this;
     }
@@ -75,10 +71,7 @@ public:
         clear();
     }
 
-    List(const List& other) : List() {
-        *this = other;
-    }
-
+    List(const List& other) = delete;
     List(List&&) = delete;
 
     List& operator=(const List& other) {
@@ -178,10 +171,7 @@ public:
     }
 
     Matrix(Matrix&&) = delete;
-
-    Matrix(const Matrix& other) : Matrix(0, 0, other.mm_alloc) {
-        *this = other;
-    }
+    Matrix(const Matrix&) = delete;
 
     Matrix& operator=(Matrix&& other) {
         if (&mm_alloc != &other.mm_alloc) {

--- a/src/include/structstore/stst_containers.hpp
+++ b/src/include/structstore/stst_containers.hpp
@@ -28,7 +28,7 @@ public:
 // instances of this class reside in shared memory, thus no raw pointers
 // or references should be used; use structstore::OffsetPtr<T> instead.
 class List : public FieldType<List> {
-    OffsetPtr<SharedAlloc, int64_t> sh_alloc;
+    OffsetPtr<SharedAlloc> sh_alloc;
     shr_vector<Field> data;
 
 public:

--- a/src/include/structstore/stst_field.hpp
+++ b/src/include/structstore/stst_field.hpp
@@ -78,8 +78,7 @@ protected:
     template<typename T>
     T& get_or_construct(SharedAlloc& sh_alloc, const FieldTypeBase* parent_field) {
         if (empty()) {
-            StlAllocator<T> tmp_alloc{sh_alloc};
-            void* ptr = tmp_alloc.allocate(1);
+            T* ptr = sh_alloc.allocate<T>();
             STST_LOG_DEBUG() << "allocating at " << ptr;
             const auto& type_info = typing::get_type<T>();
             STST_LOG_DEBUG() << "constructing field " << type_info.name << " at " << ptr;

--- a/src/include/structstore/stst_fieldmap.hpp
+++ b/src/include/structstore/stst_fieldmap.hpp
@@ -141,7 +141,7 @@ public:
         if (!ret.second) { throw std::runtime_error("field name already exists"); }
         slots.emplace_back(name_int);
         STST_LOG_DEBUG() << "field " << name << " at " << &t;
-        if constexpr (std::is_class_v<T>) {
+        if constexpr (std::is_class_v<T> && !std::is_base_of_v<OffsetPtrBase, T>) {
             t.parent_field = &parent_field;
         }
     }

--- a/src/include/structstore/stst_fieldmap.hpp
+++ b/src/include/structstore/stst_fieldmap.hpp
@@ -16,16 +16,16 @@ namespace structstore {
 // base class for managed and unmanaged FieldMap
 class FieldMapBase {
 protected:
-    MiniMalloc& mm_alloc;
+    SharedAlloc& sh_alloc;
     shr_unordered_map<const shr_string*, Field> fields;
     shr_vector<const shr_string*> slots;
 
     // constructor, assignment, destructor
 
-    explicit FieldMapBase(MiniMalloc& mm_alloc)
-        : mm_alloc(mm_alloc), fields(StlAllocator<>(mm_alloc)), slots(StlAllocator<>(mm_alloc)) {
-        STST_LOG_DEBUG() << "constructing FieldMap at " << this << " with alloc at " << &mm_alloc
-                         << " (static alloc: " << (&mm_alloc == &static_alloc) << ")";
+    explicit FieldMapBase(SharedAlloc& sh_alloc)
+        : sh_alloc(sh_alloc), fields(StlAllocator<>(sh_alloc)), slots(StlAllocator<>(sh_alloc)) {
+        STST_LOG_DEBUG() << "constructing FieldMap at " << this << " with alloc at " << &sh_alloc
+                         << " (static alloc: " << (&sh_alloc == &static_alloc) << ")";
     }
 
 public:
@@ -35,7 +35,7 @@ public:
 
     YAML::Node to_yaml() const;
 
-    void check(const MiniMalloc* mm_alloc, const FieldTypeBase& parent_field) const;
+    void check(const SharedAlloc* sh_alloc, const FieldTypeBase& parent_field) const;
 
     bool equal_slots(const FieldMapBase& other) const;
 
@@ -47,9 +47,9 @@ public:
 
     inline bool empty() const { return slots.empty(); }
 
-    inline MiniMalloc& get_alloc() { return mm_alloc; }
+    inline SharedAlloc& get_alloc() { return sh_alloc; }
 
-    inline const MiniMalloc& get_alloc() const { return mm_alloc; }
+    inline const SharedAlloc& get_alloc() const { return sh_alloc; }
 
     inline const shr_unordered_map<const shr_string*, Field>& get_fields() const { return fields; }
 
@@ -59,12 +59,10 @@ public:
 
     const Field* try_get_field(const std::string& name) const;
 
-    inline Field& at(const std::string& name) {
-        return fields.at(mm_alloc.strings().get(name));
-    }
+    inline Field& at(const std::string& name) { return fields.at(sh_alloc.strings().get(name)); }
 
     inline const Field& at(const std::string& name) const {
-        return fields.at(mm_alloc.strings().get(name));
+        return fields.at(sh_alloc.strings().get(name));
     }
 
     inline Field& at(const shr_string* name) { return fields.at(name); }
@@ -86,7 +84,7 @@ protected:
 public:
     // constructor, assignment, destructor
 
-    explicit FieldMap(MiniMalloc& mm_alloc) : FieldMapBase(mm_alloc) {}
+    explicit FieldMap(SharedAlloc& sh_alloc) : FieldMapBase(sh_alloc) {}
 
     FieldMap(const FieldMap& other) : FieldMap{static_alloc} { *this = other; }
 
@@ -125,7 +123,7 @@ public:
     void store_ref(const std::string& name, T& t, const FieldTypeBase& parent_field) {
         static_assert(!managed, "storing ref in managed FieldMap is not supported");
         if constexpr (std::is_base_of_v<Struct<T>, T>) {
-            if (&t.field_map.mm_alloc != &mm_alloc) {
+            if (&t.field_map.sh_alloc != &sh_alloc) {
                 std::ostringstream str;
                 str << "registering Struct field '" << name << "' with a different allocator "
                     << "than this FieldMap, this is probably not what you want";
@@ -133,9 +131,9 @@ public:
             }
         }
         STST_LOG_DEBUG() << "registering unmanaged data at " << &t << "in FieldMap at " << this
-                         << " with alloc at " << &mm_alloc
-                         << " (static alloc: " << (&mm_alloc == &static_alloc) << ")";
-        const shr_string* name_int = mm_alloc.strings().internalize(name);
+                         << " with alloc at " << &sh_alloc
+                         << " (static alloc: " << (&sh_alloc == &static_alloc) << ")";
+        const shr_string* name_int = sh_alloc.strings().internalize(name);
         auto ret = fields.emplace(name_int, Field{&t});
         if (!ret.second) { throw std::runtime_error("field name already exists"); }
         slots.emplace_back(name_int);
@@ -149,17 +147,17 @@ public:
 
     void clear() {
         static_assert(managed, "removing fields from unmanaged FieldMap is not supported");
-        STST_LOG_DEBUG() << "clearing FieldMap at " << this << "with alloc at " << &mm_alloc;
-        if (&mm_alloc == &static_alloc) STST_LOG_DEBUG() << "(this is using the static_alloc)";
-        for (auto& [key, value]: fields) { value.clear(mm_alloc); }
+        STST_LOG_DEBUG() << "clearing FieldMap at " << this << "with alloc at " << &sh_alloc;
+        if (&sh_alloc == &static_alloc) STST_LOG_DEBUG() << "(this is using the static_alloc)";
+        for (auto& [key, value]: fields) { value.clear(sh_alloc); }
         fields.clear();
         slots.clear();
     }
 
     void clear_unmanaged() {
         static_assert(!managed);
-        STST_LOG_DEBUG() << "clearing FieldMap at " << this << "with alloc at " << &mm_alloc;
-        if (&mm_alloc == &static_alloc) STST_LOG_DEBUG() << "(this is using the static_alloc)";
+        STST_LOG_DEBUG() << "clearing FieldMap at " << this << "with alloc at " << &sh_alloc;
+        if (&sh_alloc == &static_alloc) STST_LOG_DEBUG() << "(this is using the static_alloc)";
         for (auto& [key, value]: fields) { value.clear_unmanaged(); }
         fields.clear();
         slots.clear();
@@ -167,9 +165,9 @@ public:
 
     void remove(const std::string& name) {
         static_assert(managed, "removing fields from unmanaged FieldMap is not supported");
-        const shr_string* name_ = mm_alloc.strings().get(name);
+        const shr_string* name_ = sh_alloc.strings().get(name);
         Field& field = fields.at(name_);
-        field.clear(mm_alloc);
+        field.clear(sh_alloc);
         fields.erase(name_);
         auto slot_it = std::find(slots.begin(), slots.end(), name_);
         slots.erase(slot_it);

--- a/src/include/structstore/stst_fieldmap.hpp
+++ b/src/include/structstore/stst_fieldmap.hpp
@@ -139,8 +139,9 @@ public:
                          << " with alloc at " << &sh_alloc
                          << " (static alloc: " << (sh_alloc.get() == &static_alloc) << ")";
         shr_string_idx name_idx = sh_alloc->strings().internalize(name, *sh_alloc);
-        auto ret = fields.emplace(name_idx, Field{&t});
-        if (!ret.second) { throw std::runtime_error("field name already exists"); }
+        auto [it, inserted] = fields.emplace(name_idx, Field{});
+        if (!inserted) { throw std::runtime_error("field name already exists"); }
+        it->second.set_data(&t);
         slots.emplace_back(name_idx);
         STST_LOG_DEBUG() << "field " << name << " at " << &t;
         if constexpr (std::is_class_v<T> && !std::is_base_of_v<OffsetPtrBase<>, T>) {

--- a/src/include/structstore/stst_lock.hpp
+++ b/src/include/structstore/stst_lock.hpp
@@ -16,10 +16,10 @@ class SpinMutex {
     // randomly assigned pseudo thread id
     static thread_local uint32_t tid;
 
-    // >0 is read-locked, 0 is unlocked, <0 is write-locked
-    std::atomic_int32_t level{0};
     // thread id currently holding the write lock, or zero
     uint32_t write_lock_tid{0};
+    // >0 is read-locked, 0 is unlocked, <0 is write-locked
+    std::atomic_int16_t level{0};
 
     SpinMutex(SpinMutex&&) = delete;
 

--- a/src/include/structstore/stst_lock.hpp
+++ b/src/include/structstore/stst_lock.hpp
@@ -5,6 +5,8 @@
 
 namespace structstore {
 
+// instances of this class reside in shared memory, thus no raw pointers
+// or references should be used; use structstore::OffsetPtr<T> instead.
 class SpinMutex {
     template<bool write>
     friend class ScopedLock;

--- a/src/include/structstore/stst_lock.hpp
+++ b/src/include/structstore/stst_lock.hpp
@@ -35,6 +35,9 @@ class SpinMutex {
     void write_lock();
     void write_unlock();
 
+    void read_or_write_lock();
+    void read_or_write_unlock();
+
 public:
     SpinMutex() = default;
 };

--- a/src/include/structstore/stst_offsetptr.hpp
+++ b/src/include/structstore/stst_offsetptr.hpp
@@ -8,10 +8,11 @@
 
 namespace structstore {
 
+template<int i = 0>
 class OffsetPtrBase {};
 
 template<typename T>
-class OffsetPtr : public OffsetPtrBase {
+class OffsetPtr : public OffsetPtrBase<> {
     static constexpr std::ptrdiff_t empty_val = 1;
     std::ptrdiff_t offset = empty_val;
 
@@ -23,7 +24,7 @@ class OffsetPtr : public OffsetPtrBase {
 
 public:
     // using element_type = T;
-    using pointer = T*;
+    using pointer = OffsetPtr<T>;
     // using const_pointer = const T*;
     using difference_type = std::ptrdiff_t;
     using value_type = T;

--- a/src/include/structstore/stst_offsetptr.hpp
+++ b/src/include/structstore/stst_offsetptr.hpp
@@ -3,30 +3,22 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <type_traits>
 
 namespace structstore {
 
-template<int i = 0>
+template<typename diff_type = int32_t>
 class OffsetPtrBase {};
 
-template<typename T>
-class OffsetPtr : public OffsetPtrBase<> {
-    static constexpr std::ptrdiff_t empty_val = 1;
-    std::ptrdiff_t offset = empty_val;
-
-    static std::ptrdiff_t ptr_to_int(const void* ptr) {
-        return reinterpret_cast<const std::ptrdiff_t>(ptr);
-    }
-
-    static T* int_to_T_ptr(std::ptrdiff_t offset) { return reinterpret_cast<T*>(offset); }
-
+template<typename T, typename diff_type = int32_t>
+class OffsetPtr : public OffsetPtrBase<diff_type> {
 public:
     // using element_type = T;
-    using pointer = OffsetPtr<T>;
+    using pointer = OffsetPtr<T, int64_t>;
     // using const_pointer = const T*;
-    using difference_type = std::ptrdiff_t;
+    using difference_type = diff_type;
     using value_type = T;
     using reference = std::conditional_t<std::is_void_v<T>, int, T>&;
     // using const_reference = std::conditional_t<std::is_void_v<T>, const int, const T>&;
@@ -34,7 +26,18 @@ public:
     // template<class U>
     // using rebind = OffsetPtr<U>;
 
+    static constexpr diff_type empty_val = 1;
+    static constexpr ptrdiff_t max_ptrdiff_val = ((1ll << (8 * sizeof(diff_type) - 2)) - 1);
+
+    diff_type offset = empty_val;
+
     // static functions
+
+    static std::ptrdiff_t ptr_to_int(const void* ptr) {
+        return reinterpret_cast<const std::ptrdiff_t>(ptr);
+    }
+
+    static T* int_to_T_ptr(std::ptrdiff_t offset) { return reinterpret_cast<T*>(offset); }
 
     static OffsetPtr pointer_to(reference t) { return OffsetPtr(&t); }
 
@@ -50,9 +53,12 @@ public:
 
     OffsetPtr& operator=(T* t) {
         if (t == nullptr) {
-            offset = empty_val;
+            this->offset = this->empty_val;
         } else {
-            offset = ptr_to_int(t) - ptr_to_int(this);
+            ptrdiff_t diff = ptr_to_int(t) - ptr_to_int(this);
+            assert(diff < this->max_ptrdiff_val);
+            assert(diff > -this->max_ptrdiff_val);
+            this->offset = diff;
         }
         return *this;
     }
@@ -66,8 +72,8 @@ public:
     // explicit accessors
 
     T* get() const {
-        if (offset == empty_val) return nullptr;
-        return int_to_T_ptr(ptr_to_int(this) + offset);
+        if (this->offset == this->empty_val) return nullptr;
+        return int_to_T_ptr(ptr_to_int(this) + (ptrdiff_t) this->offset);
     }
 
     // explicit operator T*() { return get(); }
@@ -91,46 +97,41 @@ public:
     // special case for std::basic_string
     operator char*() const { return get(); }
 
-    operator OffsetPtr<void>() const { return OffsetPtr<void>(get()); }
+    operator OffsetPtr<void, diff_type>() const { return OffsetPtr<void, diff_type>(get()); }
 
-    operator OffsetPtr<const T>() const { return OffsetPtr<const T>(get()); }
+    operator OffsetPtr<const T, diff_type>() const { return OffsetPtr<const T, diff_type>(get()); }
 
     // comparison operators
 
-    bool operator==(const OffsetPtr<const T>& other) const { return get() == other.get(); }
-
-    bool operator==(const OffsetPtr<std::remove_const_t<T>>& other) const {
+    bool operator==(const OffsetPtr<const T, diff_type>& other) const {
         return get() == other.get();
     }
 
+    bool operator==(const OffsetPtr<std::remove_const_t<T>, diff_type>& other) const {
+        return get() == other.get();
+    }
+
+    bool operator==(const T* other) const { return get() == other; }
+
+    bool operator==(std::remove_const_t<T>* other) const { return get() == other; }
+
     bool operator==(std::nullptr_t) const { return !*this; }
 
-    bool operator!=(const OffsetPtr<T>& other) const { return get() != other.get(); }
+    bool operator!=(const OffsetPtr& other) const { return get() != other.get(); }
 
     bool operator!=(std::nullptr_t) const { return !!*this; }
 
     // arithmetic operators
 
-    OffsetPtr operator+(std::ptrdiff_t shift) const { return OffsetPtr(get() + shift); }
+    OffsetPtr operator+(diff_type shift) const { return OffsetPtr(get() + shift); }
 
-    OffsetPtr operator-(std::ptrdiff_t shift) const { return OffsetPtr(get() - shift); }
+    OffsetPtr operator-(diff_type shift) const { return OffsetPtr(get() - shift); }
 
-    std::ptrdiff_t operator-(const OffsetPtr& other) const { return get() - other.get(); }
+    diff_type operator-(const OffsetPtr& other) const { return get() - other.get(); }
 
     OffsetPtr& operator++() { return *this = get() + 1; }
 
     OffsetPtr& operator--() { return *this = get() - 1; }
-};
-
-struct OffsetPtrHasher {
-    const OffsetPtr<const void> base;
-
-    OffsetPtrHasher(const OffsetPtr<const void>& base) : base{base} {}
-
-    template<typename T>
-    std::size_t operator()(const OffsetPtr<const T>& ptr) const {
-        return (std::ptrdiff_t) ptr.get() - (std::ptrdiff_t) base.get();
-    }
 };
 
 } // namespace structstore

--- a/src/include/structstore/stst_offsetptr.hpp
+++ b/src/include/structstore/stst_offsetptr.hpp
@@ -8,8 +8,10 @@
 
 namespace structstore {
 
+class OffsetPtrBase {};
+
 template<typename T>
-class OffsetPtr {
+class OffsetPtr : public OffsetPtrBase {
     static constexpr std::ptrdiff_t empty_val = 1;
     std::ptrdiff_t offset = empty_val;
 
@@ -100,7 +102,11 @@ public:
         return get() == other.get();
     }
 
+    bool operator==(std::nullptr_t) const { return !*this; }
+
     bool operator!=(const OffsetPtr<T>& other) const { return get() != other.get(); }
+
+    bool operator!=(std::nullptr_t) const { return !!*this; }
 
     // arithmetic operators
 

--- a/src/include/structstore/stst_offsetptr.hpp
+++ b/src/include/structstore/stst_offsetptr.hpp
@@ -15,6 +15,8 @@ class OffsetPtrBase {};
 template<typename T, typename diff_type = int32_t>
 class OffsetPtr : public OffsetPtrBase<diff_type> {
 public:
+    static_assert(std::is_signed_v<diff_type>);
+
     // using element_type = T;
     using pointer = OffsetPtr<T, int64_t>;
     // using const_pointer = const T*;

--- a/src/include/structstore/stst_offsetptr.hpp
+++ b/src/include/structstore/stst_offsetptr.hpp
@@ -115,6 +115,17 @@ public:
     OffsetPtr& operator--() { return *this = get() - 1; }
 };
 
+struct OffsetPtrHasher {
+    const OffsetPtr<const void> base;
+
+    OffsetPtrHasher(const OffsetPtr<const void>& base) : base{base} {}
+
+    template<typename T>
+    std::size_t operator()(const OffsetPtr<const T>& ptr) const {
+        return (std::ptrdiff_t) ptr.get() - (std::ptrdiff_t) base.get();
+    }
+};
+
 } // namespace structstore
 
 #endif

--- a/src/include/structstore/stst_offsetptr.hpp
+++ b/src/include/structstore/stst_offsetptr.hpp
@@ -1,0 +1,120 @@
+#ifndef STST_OFFSETPTR_HPP
+#define STST_OFFSETPTR_HPP
+
+#include <cassert>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+
+namespace structstore {
+
+template<typename T>
+class OffsetPtr {
+    static constexpr std::ptrdiff_t empty_val = 1;
+    std::ptrdiff_t offset = empty_val;
+
+    static std::ptrdiff_t ptr_to_int(const void* ptr) {
+        return reinterpret_cast<const std::ptrdiff_t>(ptr);
+    }
+
+    static T* int_to_T_ptr(std::ptrdiff_t offset) { return reinterpret_cast<T*>(offset); }
+
+public:
+    // using element_type = T;
+    using pointer = T*;
+    // using const_pointer = const T*;
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using reference = std::conditional_t<std::is_void_v<T>, int, T>&;
+    // using const_reference = std::conditional_t<std::is_void_v<T>, const int, const T>&;
+    using iterator_category = std::random_access_iterator_tag;
+    // template<class U>
+    // using rebind = OffsetPtr<U>;
+
+    // static functions
+
+    static OffsetPtr pointer_to(reference t) { return OffsetPtr(&t); }
+
+    // constructors and assignment operators
+
+    explicit OffsetPtr() {}
+
+    OffsetPtr(T* t) { *this = t; }
+
+    OffsetPtr(const OffsetPtr& other) : OffsetPtr(other.get()) {}
+
+    OffsetPtr(OffsetPtr&& other) : OffsetPtr(other.get()) {}
+
+    OffsetPtr& operator=(T* t) {
+        if (t == nullptr) {
+            offset = empty_val;
+        } else {
+            offset = ptr_to_int(t) - ptr_to_int(this);
+        }
+        return *this;
+    }
+
+    OffsetPtr& operator=(const OffsetPtr& other) { return *this = other.get(); }
+
+    OffsetPtr& operator=(OffsetPtr&& other) { return *this = other.get(); }
+
+    ~OffsetPtr() = default;
+
+    // explicit accessors
+
+    T* get() const {
+        if (offset == empty_val) return nullptr;
+        return int_to_T_ptr(ptr_to_int(this) + offset);
+    }
+
+    // explicit operator T*() { return get(); }
+
+    reference operator*() const {
+        assert(*this);
+        return *get();
+    }
+
+    T* operator->() const { return get(); }
+
+    reference operator[](std::size_t idx) const {
+        assert(*this);
+        return get()[idx];
+    }
+
+    explicit operator bool() const { return get() != nullptr; }
+
+    // implicit conversions
+
+    // special case for std::basic_string
+    operator char*() const { return get(); }
+
+    operator OffsetPtr<void>() const { return OffsetPtr<void>(get()); }
+
+    operator OffsetPtr<const T>() const { return OffsetPtr<const T>(get()); }
+
+    // comparison operators
+
+    bool operator==(const OffsetPtr<const T>& other) const { return get() == other.get(); }
+
+    bool operator==(const OffsetPtr<std::remove_const_t<T>>& other) const {
+        return get() == other.get();
+    }
+
+    bool operator!=(const OffsetPtr<T>& other) const { return get() != other.get(); }
+
+    // arithmetic operators
+
+    OffsetPtr operator+(std::ptrdiff_t shift) const { return OffsetPtr(get() + shift); }
+
+    OffsetPtr operator-(std::ptrdiff_t shift) const { return OffsetPtr(get() - shift); }
+
+    std::ptrdiff_t operator-(const OffsetPtr& other) const { return get() - other.get(); }
+
+    OffsetPtr& operator++() { return *this = get() + 1; }
+
+    OffsetPtr& operator--() { return *this = get() - 1; }
+};
+
+} // namespace structstore
+
+#endif

--- a/src/include/structstore/stst_py.hpp
+++ b/src/include/structstore/stst_py.hpp
@@ -52,9 +52,9 @@ private:
         const ToPythonCastFn to_python_cast_fn;
     };
 
-    static std::unordered_map<uint64_t, const PyType>& get_py_types();
+    static std::unordered_map<type_hash_t, const PyType>& get_py_types();
 
-    static const PyType& get_py_type(uint64_t type_hash);
+    static const PyType& get_py_type(type_hash_t type_hash);
 
     static StructStore& get_store(StructStore& store) { return store; }
     static StructStore& get_store(StructStoreShared& store) { return *store; }
@@ -112,7 +112,7 @@ public:
     static void register_type(FromPythonFn from_python_fn, ToPythonFn to_python_fn,
                               ToPythonCastFn to_python_cast_fn = default_to_python_cast_fn<T>) {
         PyType py_type{from_python_fn, to_python_fn, to_python_cast_fn};
-        const uint64_t type_hash = typing::get_type_hash<T>();
+        const type_hash_t type_hash = typing::get_type_hash<T>();
         STST_LOG_DEBUG() << "registering Python type '" << typing::get_type<T>().name
                          << "' with hash '" << type_hash << "'";
         auto ret = get_py_types().insert({type_hash, py_type});
@@ -201,15 +201,15 @@ public:
         register_field_map_funcs(cls);
     }
 
-    static const FromPythonFn& get_from_python_fn(uint64_t type_hash) {
+    static const FromPythonFn& get_from_python_fn(type_hash_t type_hash) {
         return get_py_type(type_hash).from_python_fn;
     }
 
-    static const ToPythonFn& get_to_python_fn(uint64_t type_hash) {
+    static const ToPythonFn& get_to_python_fn(type_hash_t type_hash) {
         return get_py_type(type_hash).to_python_fn;
     }
 
-    static const ToPythonCastFn& get_to_python_cast_fn(uint64_t type_hash) {
+    static const ToPythonCastFn& get_to_python_cast_fn(type_hash_t type_hash) {
         return get_py_type(type_hash).to_python_cast_fn;
     }
 

--- a/src/include/structstore/stst_py.hpp
+++ b/src/include/structstore/stst_py.hpp
@@ -335,7 +335,7 @@ public:
 
         cls.def("__dir__", [](T& t) {
             nb::list slots;
-            for (const shr_string* str : get_field_map(t).get_slots()) {
+            for (shr_string_ptr str: get_field_map(t).get_slots()) {
                 slots.append(nb::str(str->c_str()));
             }
             return slots;

--- a/src/include/structstore/stst_py.hpp
+++ b/src/include/structstore/stst_py.hpp
@@ -136,7 +136,7 @@ public:
         static_assert(!std::is_pointer_v<T>);
         static_assert(std::is_class_v<T>);
         auto from_python_fn = [](FieldAccess<true> access, const nb::handle& value) {
-            if (access.get_type_hash() == typing::get_type_hash<T*>() && nb::isinstance<T>(value)) {
+            if (access.get_type_hash() == typing::get_type_hash<OffsetPtr<T>>() && nb::isinstance<T>(value)) {
                 STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name
                                  << " succeeded";
                 T& t = nb::cast<T&>(value, false);
@@ -144,27 +144,27 @@ public:
                     Callstack::throw_with_trace<std::runtime_error>(
                             "cannot assign pointer to different memory region");
                 }
-                access.get<T*>() = &t;
+                access.get<OffsetPtr<T>>() = &t;
                 return true;
             }
             STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name << " failed";
             return false;
         };
         py::ToPythonFn to_python_fn = [](const Field& field, py::ToPythonMode mode) {
-            T* t_ptr = field.get<T*>();
+            T* t_ptr = field.get<OffsetPtr<T>>().get();
             if (t_ptr == nullptr) {
                 return nb::none();
             }
             return field_map_to_python(t_ptr->field_map, mode);
         };
         py::ToPythonCastFn to_python_cast_fn = [](const Field& field) {
-            T* t_ptr = field.get<T*>();
+            T* t_ptr = field.get<OffsetPtr<T>>().get();
             if (t_ptr == nullptr) {
                 return nb::none();
             }
             return nb::cast(*t_ptr, nb::rv_policy::reference);
         };
-        register_type<T*>(from_python_fn, to_python_fn, to_python_cast_fn);
+        register_type<OffsetPtr<T>>(from_python_fn, to_python_fn, to_python_cast_fn);
     }
 
     template<typename T>
@@ -218,31 +218,31 @@ public:
         static_assert(!std::is_pointer_v<T>);
         static_assert(!std::is_class_v<T>);
         auto from_python_fn = [](FieldAccess<true> access, const nb::handle& value) {
-            if (access.get_type_hash() == typing::get_type_hash<T*>() && nb::isinstance<T>(value)) {
+            if (access.get_type_hash() == typing::get_type_hash<OffsetPtr<T>>() && nb::isinstance<T>(value)) {
                 STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name
                                  << " succeeded";
                 T t = nb::cast<T>(value, false);
-                *access.get<T*>() = t;
+                *access.get<OffsetPtr<T>>() = t;
                 return true;
             }
             STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name << " failed";
             return false;
         };
         py::ToPythonFn to_python_fn = [](const Field& field, py::ToPythonMode) {
-            T* t_ptr = field.get<T*>();
+            T* t_ptr = field.get<OffsetPtr<T>>().get();
             if (t_ptr == nullptr) {
                 return nb::none();
             }
             return nb::cast(*t_ptr);
         };
         py::ToPythonCastFn to_python_cast_fn = [](const Field& field) {
-            T* t_ptr = field.get<T*>();
+            T* t_ptr = field.get<OffsetPtr<T>>().get();
             if (t_ptr == nullptr) {
                 return nb::none();
             }
             return nb::cast(*t_ptr);
         };
-        register_type<T*>(from_python_fn, to_python_fn, to_python_cast_fn);
+        register_type<OffsetPtr<T>>(from_python_fn, to_python_fn, to_python_cast_fn);
     }
 
     template<typename T, typename T_py>

--- a/src/include/structstore/stst_py.hpp
+++ b/src/include/structstore/stst_py.hpp
@@ -338,8 +338,9 @@ public:
 
         cls.def("__dir__", [](T& t) {
             nb::list slots;
-            for (shr_string_ptr str: get_field_map(t).get_slots()) {
-                slots.append(nb::str(str->c_str()));
+            const auto& field_map = get_field_map(t);
+            for (shr_string_idx str_idx: field_map.get_slots()) {
+                slots.append(nb::str(field_map.get_alloc().strings().get(str_idx)->c_str()));
             }
             return slots;
         });

--- a/src/include/structstore/stst_py.hpp
+++ b/src/include/structstore/stst_py.hpp
@@ -42,6 +42,7 @@ public:
     using ToPythonFn = std::function<nb::object(const Field&, ToPythonMode mode)>;
     using ToPythonCastFn = std::function<nb::object(const Field&)>;
 
+    __attribute__((__visibility__("default")))
     static nb::object SimpleNamespace;
 
 private:
@@ -342,6 +343,8 @@ public:
             }
             return slots;
         });
+
+        cls.def("__len__", [](T& t) { return get_field_map(t).get_slots().size(); });
 
         if constexpr (typing::is_field_type<T>) {
             cls.def("__setstate__", [](T& t, nb::handle value) {

--- a/src/include/structstore/stst_py.hpp
+++ b/src/include/structstore/stst_py.hpp
@@ -42,6 +42,8 @@ public:
     using ToPythonFn = std::function<nb::object(const Field&, ToPythonMode mode)>;
     using ToPythonCastFn = std::function<nb::object(const Field&)>;
 
+    static nb::object SimpleNamespace;
+
 private:
     struct __attribute__((__visibility__("default"))) PyType {
         const FromPythonFn from_python_fn;
@@ -329,8 +331,8 @@ public:
         register_complex_type_funcs<T>(cls);
 
         cls.def("__getstate__", [](T& t) {
-            nb::object dict = field_map_to_python(get_field_map(t), py::ToPythonMode::RECURSIVE);
-            return dict;
+            nb::object obj = field_map_to_python(get_field_map(t), py::ToPythonMode::RECURSIVE);
+            return obj;
         });
 
         cls.def("__dir__", [](T& t) {

--- a/src/include/structstore/stst_py.hpp
+++ b/src/include/structstore/stst_py.hpp
@@ -39,11 +39,10 @@ public:
     };
 
     using FromPythonFn = std::function<bool(FieldAccess<true>, const nb::handle&)>;
-    using ToPythonFn = std::function<nb::object(const Field&, ToPythonMode mode)>;
-    using ToPythonCastFn = std::function<nb::object(const Field&)>;
+    using ToPythonFn = std::function<nb::object(const FieldView&, ToPythonMode mode)>;
+    using ToPythonCastFn = std::function<nb::object(const FieldView&)>;
 
-    __attribute__((__visibility__("default")))
-    static nb::object SimpleNamespace;
+    __attribute__((__visibility__("default"))) static nb::object SimpleNamespace;
 
 private:
     struct __attribute__((__visibility__("default"))) PyType {
@@ -63,52 +62,49 @@ private:
     static void set_field(FieldMap<true>& field_map, const std::string& name,
                           const nb::handle& value, const FieldTypeBase& parent_field);
 
-    static nb::object __repr__(StructStore& store);
-
-    static nb::object copy(StructStore& store);
-
-    static nb::object deepcopy(StructStore& store);
-
-    static nb::object __copy__(StructStore& store);
-
-    static nb::object __deepcopy__(StructStore& store, nb::handle&);
-
 public:
-    template<typename T, typename T_py>
+    template<typename W, typename W_py>
     static bool default_from_python_fn(FieldAccess<true> access, const nb::handle& value) {
+        using T = unwrap_type_t<W>;
         if (nb::isinstance<T>(value)) {
             STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name
                              << " succeeded";
-            const T& t = nb::cast<T>(value, false);
-            access.get<T>() = t;
+            const W& w = nb::cast<W>(value, false);
+            access.get<T>() = unwrap<W>(w);
             return true;
         }
         STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name << " failed";
         return false;
     }
 
-    template<typename T, typename T_py>
-    static nb::object default_to_python_fn(const Field& field, ToPythonMode) {
-        return T_py(field.get<T>());
+    template<typename W, typename W_py>
+    static nb::object default_to_python_fn(const FieldView& field_view, ToPythonMode) {
+        using T = unwrap_type_t<W>;
+        return W_py(ref_wrap(field_view.get<T>()));
     }
 
-    template<typename T>
-    static nb::object default_to_python_cast_fn(const Field& field) {
-        T& t = field.get<T>();
-        return nb::cast(t, nb::rv_policy::reference);
+    template<typename W>
+    static nb::object default_to_python_cast_fn(const FieldView& field_view) {
+        using T = unwrap_type_t<W>;
+        return nb::cast(ref_wrap(field_view.get<T>()), nb::rv_policy::reference);
     }
 
-    template<typename T>
+    template<typename W>
     static void register_type(FromPythonFn from_python_fn, ToPythonFn to_python_fn,
-                              ToPythonCastFn to_python_cast_fn = default_to_python_cast_fn<T>) {
+                              ToPythonCastFn to_python_cast_fn = default_to_python_cast_fn<W>) {
+        static_assert(std::is_same_v<W, std::remove_const_t<W>>);
+        static_assert(std::is_same_v<W, std::remove_reference_t<W>>);
+        // check that a wrapper type (or String) is provided:
+        static_assert(std::is_same_v<std::remove_reference_t<wrap_type_w<W>>, W>);
+        using T = unwrap_type_t<W>;
+        static_assert(typing::is_field_type<unwrap_type_t<W>>);
+
         PyType py_type{from_python_fn, to_python_fn, to_python_cast_fn};
         const type_hash_t type_hash = typing::get_type_hash<T>();
         STST_LOG_DEBUG() << "registering Python type '" << typing::get_type<T>().name
                          << "' with hash '" << type_hash << "'";
         auto ret = get_py_types().insert({type_hash, py_type});
-        if (!ret.second) {
-            throw typing::already_registered_type_error(type_hash);
-        }
+        if (!ret.second) { throw typing::already_registered_type_error(type_hash); }
     }
 
     static nb::object field_map_to_python(const FieldMapBase& field_map, py::ToPythonMode mode);
@@ -121,18 +117,20 @@ public:
         return field_map_to_python(store.field_map, mode);
     }
 
-    template<typename T>
+    template<typename W>
     static void register_struct_ptr_type() {
+        using T = unwrap_type_t<W>;
         static_assert(!std::is_pointer_v<T>);
         static_assert(std::is_class_v<T>);
         auto from_python_fn = [](FieldAccess<true> access, const nb::handle& value) {
-            if (access.get_type_hash() == typing::get_type_hash<OffsetPtr<T>>() && nb::isinstance<T>(value)) {
+            if (access.get_type_hash() == typing::get_type_hash<OffsetPtr<T>>() &&
+                nb::isinstance<W>(value)) {
                 STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name
                                  << " succeeded";
-                T& t = nb::cast<T&>(value, false);
+                W& w = nb::cast<W&>(value, false);
+                T& t = unwrap(w);
                 if (!access.get_alloc().is_owned(&t)) {
-                    Callstack::throw_with_trace<std::runtime_error>(
-                            "cannot assign pointer to different memory region");
+                    Callstack::throw_with_trace("cannot assign pointer to different memory region");
                 }
                 access.get<OffsetPtr<T>>() = &t;
                 return true;
@@ -140,33 +138,33 @@ public:
             STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name << " failed";
             return false;
         };
-        py::ToPythonFn to_python_fn = [](const Field& field, py::ToPythonMode mode) {
-            T* t_ptr = field.get<OffsetPtr<T>>().get();
-            if (t_ptr == nullptr) {
-                return nb::none();
-            }
+        py::ToPythonFn to_python_fn = [](const FieldView& field_view, py::ToPythonMode mode) {
+            T* t_ptr = field_view.get<OffsetPtr<T>>().get();
+            if (t_ptr == nullptr) { return nb::none(); }
             return field_map_to_python(t_ptr->field_map, mode);
         };
-        py::ToPythonCastFn to_python_cast_fn = [](const Field& field) {
-            T* t_ptr = field.get<OffsetPtr<T>>().get();
-            if (t_ptr == nullptr) {
-                return nb::none();
-            }
-            return nb::cast(*t_ptr, nb::rv_policy::reference);
+        py::ToPythonCastFn to_python_cast_fn = [](const FieldView& field_view) {
+            T* t_ptr = field_view.get<OffsetPtr<T>>().get();
+            if (t_ptr == nullptr) { return nb::none(); }
+            return nb::cast(ref_wrap(*t_ptr), nb::rv_policy::reference);
         };
         register_type<OffsetPtr<T>>(from_python_fn, to_python_fn, to_python_cast_fn);
     }
 
-    template<typename T>
-    static void register_struct_type(nb::class_<T>& cls) {
+    template<typename W>
+    static void register_struct_type(nb::class_<W>& cls) {
+        using T = unwrap_type_t<W>;
         static_assert(std::is_base_of_v<Struct<T>, T>);
         static_assert(std::is_same_v<T, std::remove_cv_t<T>>);
-        py::ToPythonFn to_python_fn = [](const Field& field, py::ToPythonMode mode) {
-            Struct<T>& t = field.get<T>();
+        static_assert(std::is_same_v<typename T::Ref, W>);
+        cls.def("__init__",
+                [](typename T::Ref* struct_ref) { T::Ref::create_in_place(struct_ref); });
+        py::ToPythonFn to_python_fn = [](const FieldView& field_view, py::ToPythonMode mode) {
+            Struct<T>& t = field_view.get<T>();
             return field_map_to_python(t.field_map, mode);
         };
         auto from_python_fn = [](FieldAccess<true> access, const nb::handle& value) {
-            if (py::copy_cast_from_python<T>(access, value)) { return true; }
+            if (py::copy_cast_from_python<W>(access, value)) { return true; }
             nb::dict dict;
             bool is_dict = false;
             if (nb::hasattr(value, "__dict__")) {
@@ -186,8 +184,8 @@ public:
             STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name << " failed";
             return false;
         };
-        register_type<T>(from_python_fn, to_python_fn);
-        register_struct_ptr_type<T>();
+        register_type<W>(from_python_fn, to_python_fn);
+        register_struct_ptr_type<W>();
         register_field_map_funcs(cls);
     }
 
@@ -203,12 +201,15 @@ public:
         return get_py_type(type_hash).to_python_cast_fn;
     }
 
-    template<typename T>
+    template<typename W>
     static void register_basic_ptr_type() {
+        using T = unwrap_type_t<W>;
+        static_assert(std::is_same_v<T, W>);
         static_assert(!std::is_pointer_v<T>);
         static_assert(!std::is_class_v<T>);
         auto from_python_fn = [](FieldAccess<true> access, const nb::handle& value) {
-            if (access.get_type_hash() == typing::get_type_hash<OffsetPtr<T>>() && nb::isinstance<T>(value)) {
+            if (access.get_type_hash() == typing::get_type_hash<OffsetPtr<T>>() &&
+                nb::isinstance<T>(value)) {
                 STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name
                                  << " succeeded";
                 T t = nb::cast<T>(value, false);
@@ -218,112 +219,119 @@ public:
             STST_LOG_DEBUG() << "converting from type " << typing::get_type<T>().name << " failed";
             return false;
         };
-        py::ToPythonFn to_python_fn = [](const Field& field, py::ToPythonMode) {
-            T* t_ptr = field.get<OffsetPtr<T>>().get();
-            if (t_ptr == nullptr) {
-                return nb::none();
-            }
-            return nb::cast(*t_ptr);
+        py::ToPythonFn to_python_fn = [](const FieldView& field_view, py::ToPythonMode) {
+            T* t_ptr = field_view.get<OffsetPtr<T>>().get();
+            if (t_ptr == nullptr) { return nb::none(); }
+            return nb::cast(ref_wrap(*t_ptr));
         };
-        py::ToPythonCastFn to_python_cast_fn = [](const Field& field) {
-            T* t_ptr = field.get<OffsetPtr<T>>().get();
-            if (t_ptr == nullptr) {
-                return nb::none();
-            }
-            return nb::cast(*t_ptr);
+        py::ToPythonCastFn to_python_cast_fn = [](const FieldView& field_view) {
+            T* t_ptr = field_view.get<OffsetPtr<T>>().get();
+            if (t_ptr == nullptr) { return nb::none(); }
+            return nb::cast(ref_wrap(*t_ptr));
         };
         register_type<OffsetPtr<T>>(from_python_fn, to_python_fn, to_python_cast_fn);
     }
 
-    template<typename T, typename T_py>
+    template<typename W, typename W_py>
     static void register_basic_type() {
-        register_type<T>(default_from_python_fn<T, T_py>, default_to_python_fn<T, T_py>,
-                         default_to_python_cast_fn<T>);
-        register_basic_ptr_type<T>();
+        using T = unwrap_type_t<W>;
+        static_assert(std::is_same_v<T, W>);
+        register_type<W>(default_from_python_fn<W, W_py>, default_to_python_fn<W, W_py>,
+                         default_to_python_cast_fn<W>);
+        register_basic_ptr_type<W>();
     }
 
-    template<typename T>
-    static void register_complex_type_funcs(nb::class_<T>& cls) {
+    template<typename W>
+    static void register_complex_type_funcs(nb::class_<W>& cls) {
+        using T = unwrap_type_t<W>;
         static_assert(!std::is_pointer_v<T>);
-        cls.def("to_yaml", [](T& t) { return YAML::Dump(FieldView(t)->to_yaml()); });
-        cls.def("__repr__", [](T& t) {
+        cls.def("to_yaml", [](W& w) { return YAML::Dump(FieldView{unwrap(w)}.to_yaml()); });
+        cls.def("__repr__", [](W& w) {
             std::ostringstream str;
-            FieldView(t)->to_text(str);
+            FieldView{unwrap(w)}.to_text(str);
             return str.str();
         });
-        cls.def("copy", [](T& t) {
-            return to_python(*FieldView{t}, ToPythonMode::NON_RECURSIVE);
+        cls.def("copy",
+                [](W& w) { return to_python(FieldView{unwrap(w)}, ToPythonMode::NON_RECURSIVE); });
+        cls.def("deepcopy",
+                [](W& w) { return to_python(FieldView{unwrap(w)}, ToPythonMode::RECURSIVE); });
+        cls.def("__copy__",
+                [](W& w) { return to_python(FieldView{unwrap(w)}, ToPythonMode::NON_RECURSIVE); });
+        cls.def("__deepcopy__", [](W& w, nb::handle&) {
+            return to_python(FieldView{unwrap(w)}, ToPythonMode::RECURSIVE);
         });
-        cls.def("deepcopy", [](T& t) {
-            return to_python(*FieldView{t}, ToPythonMode::RECURSIVE);
-        });
-        cls.def("__copy__", [](T& t) {
-            return to_python(*FieldView{t}, ToPythonMode::NON_RECURSIVE);
-        });
-        cls.def("__deepcopy__", [](T& t, nb::handle&) {
-            return to_python(*FieldView{t}, ToPythonMode::RECURSIVE);
-        });
-        cls.def("__eq__", [](T& t, nb::handle& other) {
-            if (const T* other_ = try_cast<T>(other)) {
-                return t == *other_;
-            }
+        cls.def("__eq__", [](W& w, nb::handle& other) {
+            if (const W* other_ = try_cast<W>(other)) { return unwrap(w) == unwrap(*other_); }
             return false;
         });
-        cls.def("read_lock", [](T& t) { return unwrap(t).read_lock(); }, nb::rv_policy::move);
-        cls.def("write_lock", [](T& t) { return unwrap(t).write_lock(); }, nb::rv_policy::move);
+        cls.def("read_lock", [](W& w) { return unwrap(w).read_lock(); }, nb::rv_policy::move);
+        cls.def("write_lock", [](W& w) { return unwrap(w).write_lock(); }, nb::rv_policy::move);
     }
 
-    template<typename T>
-    static T* try_cast(const nb::handle& value) {
+    template<typename W>
+    static W* try_cast(const nb::handle& value) {
         try {
-            return &nb::cast<T&>(value, false);
-        } catch (const nb::cast_error&) {
-            return nullptr;
-        }
+            return &nb::cast<W&>(value, false);
+        } catch (const nb::cast_error&) { return nullptr; }
     }
 
-    template<typename T>
+    template<typename W>
     static bool copy_cast_from_python(FieldAccess<true> access, const nb::handle& value) {
-        T* value_cpp = try_cast<T>(value);
-        if (value_cpp == nullptr) {
-            return false;
-        }
+        using T = unwrap_type_t<W>;
+        // check that a wrapper type (or String) is provided:
+        static_assert(std::is_same_v<std::remove_reference_t<wrap_type_w<W>>, W>);
+
+        W* value_cpp_ptr = try_cast<W>(value);
+        if (value_cpp_ptr == nullptr) { return false; }
+        T& value_cpp = unwrap(*value_cpp_ptr);
         T& field_cpp = access.get<T>();
         STST_LOG_DEBUG() << "at type " << typing::get_type<T>().name;
-        if (value_cpp == &field_cpp) {
+        if (&value_cpp == &field_cpp) {
             STST_LOG_DEBUG() << "copying to itself";
             return true;
         }
-        STST_LOG_DEBUG() << "copying " << typing::get_type<T>().name << " from " << value_cpp << " to " << &field_cpp;
-        field_cpp = *value_cpp;
+        STST_LOG_DEBUG() << "copying " << typing::get_type<T>().name << " from " << &value_cpp
+                         << " to " << &field_cpp;
+        field_cpp = value_cpp;
         return true;
     }
 
-    template<typename T>
-    static void register_field_map_funcs(nb::class_<T>& cls) {
-        register_complex_type_funcs<T>(cls);
+    template<typename W>
+    static void register_field_map_funcs(nb::class_<W>& cls) {
+        using T = unwrap_type_t<W>;
+        register_complex_type_funcs<W>(cls);
 
-        cls.def("__getstate__", [](T& t) {
-            nb::object obj = field_map_to_python(unwrap(t).field_map, py::ToPythonMode::RECURSIVE);
+        cls.def("__getstate__", [](W& w) {
+            CallstackEntry entry{"py::__getstate__()"};
+            nb::object obj = field_map_to_python(unwrap(w).field_map, py::ToPythonMode::RECURSIVE);
             return obj;
         });
 
-        cls.def("__dir__", [](T& t) {
+        cls.def("__dir__", [](W& w) {
             nb::list slots;
-            const auto& field_map = unwrap(t).field_map;
+            const auto& field_map = unwrap(w).field_map;
             for (shr_string_idx str_idx: field_map.get_slots()) {
                 slots.append(nb::str(field_map.get_alloc().strings().get(str_idx)->c_str()));
             }
             return slots;
         });
 
-        cls.def("__len__", [](T& t) { return unwrap(t).field_map.get_slots().size(); });
+        cls.def("__len__", [](W& w) { return unwrap(w).field_map.get_slots().size(); });
 
-        if constexpr (typing::is_field_type<T>) {
-            cls.def("__setstate__", [](T& t, nb::handle value) {
-                typing::get_type<T>().constructor_fn(static_alloc, &t, nullptr);
-                from_python(FieldAccess<true>{*FieldView{t}, static_alloc, nullptr}, value,
-                            "<root>");
+        if constexpr (std::is_base_of_v<FieldType<T>, T> && !std::is_same_v<W, StructStoreShared>) {
+            cls.def("__setstate__", [](W& w, nb::handle value) {
+                CallstackEntry entry{"py::__setstate__()"};
+                using T = unwrap_type_t<W>;
+                static_assert(std::is_same_v<typename T::Ref, W>);
+                // create temporary field to be able to call from_python()
+                Field* field = static_alloc.allocate<Field>();
+                new (field) Field;
+                auto access = FieldAccess<true>{*field, static_alloc, nullptr};
+                // ensure that the field has the desired type T
+                access.get<T>();
+                from_python(access, value, "<root>");
+                new (&w) typename T::Ref{std::move(*field), static_alloc};
+                static_alloc.deallocate(field);
             });
         } else {
             cls.def("__setstate__", [](T&, nb::handle) {
@@ -333,13 +341,13 @@ public:
 
         cls.def(
                 "__getattr__",
-                [](T& t, const std::string& name) { return get_field(unwrap(t).field_map, name); },
+                [](W& w, const std::string& name) { return get_field(unwrap(w).field_map, name); },
                 nb::arg("name"));
 
         cls.def(
                 "__setattr__",
-                [](T& t, const std::string& name, const nb::handle& value) {
-                    auto& val = unwrap(t);
+                [](W& w, const std::string& name, const nb::handle& value) {
+                    auto& val = unwrap(w);
                     auto lock = val.write_lock();
                     return set_field(val.field_map, name, value, val);
                 },
@@ -347,50 +355,54 @@ public:
 
         cls.def(
                 "__getitem__",
-                [](T& t, const std::string& name) {
+                [](W& w, const std::string& name) {
                     // todo: when returning a field, there should be a read lock on the parent StructStore
                     // => attach a read lock to the return value?
-                    return get_field(unwrap(t).field_map, name);
+                    return get_field(unwrap(w).field_map, name);
                 },
                 nb::arg("name"));
 
         cls.def(
                 "__setitem__",
-                [](T& t, const std::string& name, const nb::handle& value) {
-                    auto& val = unwrap(t);
+                [](W& w, const std::string& name, const nb::handle& value) {
+                    auto& val = unwrap(w);
                     auto lock = val.write_lock();
                     return set_field(val.field_map, name, value, val);
                 },
                 nb::arg("name"), nb::arg("value").none());
 
-        cls.def("empty", [](T& t) { return unwrap(t).field_map.empty(); });
+        cls.def("empty", [](W& w) { return unwrap(w).field_map.empty(); });
     }
 
-    template<typename T>
-    static void register_structstore_funcs(nb::class_<T>& cls) {
-        register_field_map_funcs<T>(cls);
+    template<typename W>
+    static void register_structstore_funcs(nb::class_<W>& cls) {
+        register_field_map_funcs<W>(cls);
 
-        cls.def("clear", [](T& t) { unwrap(t).clear(); });
+        cls.def("clear", [](W& w) { unwrap(w).clear(); });
 
-        cls.def("check", [](T& t) {
+        cls.def("check", [](W& w) {
             STST_LOG_DEBUG() << "checking from python ...";
-            t.check();
+            w.check();
         });
 
         cls.def(
                 "__delattr__",
-                [](T& t, const std::string& name) { return unwrap(t).field_map.remove(name.c_str()); },
+                [](W& w, const std::string& name) {
+                    return unwrap(w).field_map.remove(name.c_str());
+                },
                 nb::arg("name"));
 
         cls.def(
                 "__delitem__",
-                [](T& t, const std::string& name) { return unwrap(t).field_map.remove(name.c_str()); },
+                [](W& w, const std::string& name) {
+                    return unwrap(w).field_map.remove(name.c_str());
+                },
                 nb::arg("name"));
     }
 
-    static nb::object to_python(const Field& field, ToPythonMode mode);
+    static nb::object to_python(const FieldView& field_view, ToPythonMode mode);
 
-    static nb::object to_python_cast(const Field& field);
+    static nb::object to_python_cast(const FieldView& field_view);
 
     // for unmanaged fields
     static void from_python(FieldAccess<false> access, const nb::handle& value,

--- a/src/include/structstore/stst_shared.hpp
+++ b/src/include/structstore/stst_shared.hpp
@@ -80,7 +80,7 @@ class StructStoreShared {
         SharedData* original_ptr;
         size_t size;
         std::atomic_int32_t usage_count;
-        MiniMalloc mm_alloc;
+        SharedAlloc sh_alloc;
         StructStore* store;
         std::atomic_bool invalidated;
 

--- a/src/include/structstore/stst_shared.hpp
+++ b/src/include/structstore/stst_shared.hpp
@@ -76,12 +76,13 @@ class StructStoreShared {
 
     StructStoreShared& operator=(const StructStoreShared&) = delete;
 
+    // instances of this class reside in shared memory, thus no raw pointers
+    // or references should be used; use structstore::OffsetPtr<T> instead.
     struct SharedData {
-        SharedData* original_ptr;
         size_t size;
         std::atomic_int32_t usage_count;
         SharedAlloc sh_alloc;
-        StructStore* store;
+        OffsetPtr<StructStore> store;
         std::atomic_bool invalidated;
 
         SharedData(size_t size, size_t bufsize, void* buffer);
@@ -107,8 +108,7 @@ class StructStoreShared {
 
 public:
     explicit StructStoreShared(const std::string& path, size_t bufsize = 4096, bool reinit = false,
-                               bool use_file = false, CleanupMode cleanup = IF_LAST,
-                               void* target_addr = nullptr);
+                               bool use_file = false, CleanupMode cleanup = IF_LAST);
 
     explicit StructStoreShared(int fd, bool init);
 
@@ -147,12 +147,12 @@ public:
 
     StructStore* operator->() {
         assert_valid();
-        return sh_data_ptr->store;
+        return sh_data_ptr->store.get();
     }
 
     StructStore& operator*() {
         assert_valid();
-        return *sh_data_ptr->store;
+        return *sh_data_ptr->store.get();
     }
 
     FieldAccess<true> operator[](const std::string& name) {

--- a/src/include/structstore/stst_shared.hpp
+++ b/src/include/structstore/stst_shared.hpp
@@ -192,9 +192,12 @@ public:
 
 template<>
 struct Unwrapper<StructStoreShared> {
-    StructStore& val;
-    Unwrapper(StructStoreShared& t) : val{*t} {}
+    using T = StructStore;
+    StructStore& t;
+    Unwrapper(StructStoreShared& w) : t{*w} {}
 };
+static_assert(std::is_same_v<unwrap_type_t<StructStoreShared>, StructStore>);
+static_assert(std::is_same_v<wrap_type_w<StructStoreShared>, StructStoreShared&>);
 
 }  // namespace structstore
 

--- a/src/include/structstore/stst_shared.hpp
+++ b/src/include/structstore/stst_shared.hpp
@@ -190,6 +190,12 @@ public:
     void check() const;
 };
 
+template<>
+struct Unwrapper<StructStoreShared> {
+    StructStore& val;
+    Unwrapper(StructStoreShared& t) : val{*t} {}
+};
+
 }  // namespace structstore
 
 #endif

--- a/src/include/structstore/stst_struct.hpp
+++ b/src/include/structstore/stst_struct.hpp
@@ -9,6 +9,8 @@ namespace structstore {
 
 class py;
 
+// instances of this class reside in shared memory, thus no raw pointers
+// or references should be used; use structstore::OffsetPtr<T> instead.
 template<typename T>
 class Struct : public FieldType<T> {
     friend class structstore::py;

--- a/src/include/structstore/stst_struct.hpp
+++ b/src/include/structstore/stst_struct.hpp
@@ -23,7 +23,7 @@ protected:
 
     Struct() : Struct(static_alloc) {}
 
-    explicit Struct(MiniMalloc& mm_alloc) : field_map(mm_alloc) {}
+    explicit Struct(SharedAlloc& sh_alloc) : field_map(sh_alloc) {}
 
     Struct(const Struct&) = delete;
     Struct(Struct&&) = delete;
@@ -48,9 +48,9 @@ public:
 
     inline YAML::Node to_yaml() const { return field_map.to_yaml(); }
 
-    void check(const MiniMalloc* mm_alloc = nullptr) const {
+    void check(const SharedAlloc* sh_alloc = nullptr) const {
         CallstackEntry entry{"structstore::Struct::check()"};
-        field_map.check(mm_alloc, *this);
+        field_map.check(sh_alloc, *this);
     }
 
     inline bool operator==(const Struct& other) const { return field_map == other.field_map; }

--- a/src/include/structstore/stst_structstore.hpp
+++ b/src/include/structstore/stst_structstore.hpp
@@ -18,6 +18,7 @@ class py;
 class StructStore : public FieldType<StructStore> {
     friend class ::structstore::typing;
     friend class ::structstore::SharedAlloc;
+    friend class ::structstore::StlAllocator<StructStore>;
     friend class ::structstore::StructStoreShared;
     friend class ::structstore::py;
 
@@ -74,7 +75,7 @@ public:
         return (*this)[name];
     }
 
-    inline StructStore& substore(const std::string& name) { return get<StructStore>(name); }
+    StructStore& substore(const std::string& name) { return get<StructStore>(name); }
 
     // remove operations
 

--- a/src/include/structstore/stst_structstore.hpp
+++ b/src/include/structstore/stst_structstore.hpp
@@ -23,7 +23,7 @@ protected:
 public:
     // constructor, assignment, destructor
 
-    explicit StructStore(MiniMalloc& mm_alloc) : field_map(mm_alloc) {}
+    explicit StructStore(SharedAlloc& sh_alloc) : field_map(sh_alloc) {}
 
     StructStore(const StructStore& other) : StructStore{static_alloc} { *this = other; }
 
@@ -46,7 +46,7 @@ public:
 
     inline YAML::Node to_yaml() const { return field_map.to_yaml(); }
 
-    void check(const MiniMalloc* mm_alloc = nullptr) const;
+    void check(const SharedAlloc* sh_alloc = nullptr) const;
 
     inline bool operator==(const StructStore& other) const { return field_map == other.field_map; }
 
@@ -54,7 +54,7 @@ public:
 
     inline bool empty() const { return field_map.empty(); }
 
-    inline MiniMalloc& get_alloc() { return field_map.get_alloc(); }
+    inline SharedAlloc& get_alloc() { return field_map.get_alloc(); }
 
     FieldAccess<true> at(const std::string& name);
 

--- a/src/include/structstore/stst_structstore.hpp
+++ b/src/include/structstore/stst_structstore.hpp
@@ -28,12 +28,12 @@ public:
 protected:
     FieldMap<true> field_map;
 
-    explicit StructStore(SharedAlloc& sh_alloc) : field_map(sh_alloc) {}
-
     StructStore(const StructStore& other) : StructStore{static_alloc} { *this = other; }
 
 public:
     // constructor, assignment, destructor
+
+    explicit StructStore(SharedAlloc& sh_alloc) : field_map(sh_alloc) {}
 
     StructStore& operator=(const StructStore& other) {
         field_map.copy_from(other.field_map, this);
@@ -83,6 +83,9 @@ public:
 
     inline void remove(const std::string& name) { field_map.remove(name); }
 };
+
+static_assert(std::is_same_v<unwrap_type_t<FieldRef<StructStore>>, StructStore>);
+static_assert(std::is_same_v<wrap_type_w<StructStore>, FieldRef<StructStore>>);
 } // namespace structstore
 
 #endif

--- a/src/include/structstore/stst_structstore.hpp
+++ b/src/include/structstore/stst_structstore.hpp
@@ -16,7 +16,10 @@ class py;
 // instances of this class reside in shared memory, thus no raw pointers
 // or references should be used; use structstore::OffsetPtr<T> instead.
 class StructStore : public FieldType<StructStore> {
-    friend class py;
+    friend class ::structstore::typing;
+    friend class ::structstore::SharedAlloc;
+    friend class ::structstore::StructStoreShared;
+    friend class ::structstore::py;
 
 public:
     static const TypeInfo& type_info;
@@ -24,12 +27,12 @@ public:
 protected:
     FieldMap<true> field_map;
 
-public:
-    // constructor, assignment, destructor
-
     explicit StructStore(SharedAlloc& sh_alloc) : field_map(sh_alloc) {}
 
     StructStore(const StructStore& other) : StructStore{static_alloc} { *this = other; }
+
+public:
+    // constructor, assignment, destructor
 
     StructStore& operator=(const StructStore& other) {
         field_map.copy_from(other.field_map, this);

--- a/src/include/structstore/stst_structstore.hpp
+++ b/src/include/structstore/stst_structstore.hpp
@@ -11,6 +11,10 @@ namespace structstore {
 
 class py;
 
+// todo: when returning a FieldAccess, there should be a read lock on the parent StructStore
+
+// instances of this class reside in shared memory, thus no raw pointers
+// or references should be used; use structstore::OffsetPtr<T> instead.
 class StructStore : public FieldType<StructStore> {
     friend class py;
 

--- a/src/include/structstore/stst_typing.hpp
+++ b/src/include/structstore/stst_typing.hpp
@@ -22,13 +22,15 @@ class StructStore;
 template<typename T>
 class Struct;
 
+// instances of this class reside in shared memory, thus no raw pointers
+// or references should be used; use structstore::OffsetPtr<T> instead.
 class FieldTypeBase {
 protected:
     template<bool write>
     friend class ScopedFieldLock;
     friend class py;
 
-    const FieldTypeBase* parent_field = nullptr;
+    OffsetPtr<const FieldTypeBase> parent_field = nullptr;
     mutable SpinMutex mutex = {};
 
     FieldTypeBase() {}

--- a/src/include/structstore/stst_typing.hpp
+++ b/src/include/structstore/stst_typing.hpp
@@ -19,8 +19,6 @@ namespace structstore {
 
 using type_hash_t = uint32_t;
 
-class StructStore;
-
 template<typename T>
 class Struct;
 
@@ -80,6 +78,8 @@ public:
         }
 
     public:
+        using Ref = FieldRef<T>;
+
         static FieldRef<T> create() { return FieldRef<T>::create(); }
 
         friend std::ostream& operator<<(std::ostream& os, const FieldType<T>& t) {
@@ -131,7 +131,7 @@ private:
         ti.type_hash = -1;
         ti.name = name;
         ti.size = sizeof(T);
-        if constexpr (std::is_constructible_v<T, SharedAlloc&> || std::is_same_v<T, StructStore>) {
+        if constexpr (std::is_constructible_v<T, SharedAlloc&>) {
             ti.constructor_fn = [](SharedAlloc& sh_alloc, void* t,
                                    const FieldTypeBase* parent_field) {
                 new (t) T(sh_alloc);

--- a/src/include/structstore/stst_typing.hpp
+++ b/src/include/structstore/stst_typing.hpp
@@ -43,6 +43,8 @@ protected:
     void read_unlock_() const;
     void write_lock_() const;
     void write_unlock_() const;
+    void read_or_write_lock_() const;
+    void read_or_write_unlock_() const;
 
 public:
     [[nodiscard]] ScopedFieldLock<false> read_lock() const { return ScopedFieldLock<false>(*this); }

--- a/src/include/structstore/stst_typing.hpp
+++ b/src/include/structstore/stst_typing.hpp
@@ -54,6 +54,9 @@ public:
     [[nodiscard]] ScopedFieldLock<true> write_lock() const { return ScopedFieldLock<true>(*this); }
 };
 
+template<typename T>
+class FieldRef;
+
 class typing {
 public:
     template<typename T>
@@ -77,6 +80,8 @@ public:
         }
 
     public:
+        static FieldRef<T> create() { return FieldRef<T>::create(); }
+
         friend std::ostream& operator<<(std::ostream& os, const FieldType<T>& t) {
             ((const T&) t).to_text(os);
             return os;

--- a/src/include/structstore/stst_utils.hpp
+++ b/src/include/structstore/stst_utils.hpp
@@ -60,10 +60,7 @@ class NilLog {
 
 #define stst_assert(expr)                                                                          \
     do {                                                                                           \
-        if (!(expr)) {                                                                             \
-            structstore::Callstack::throw_with_trace<std::runtime_error>(                          \
-                    "assertion failed: " #expr);                                                   \
-        }                                                                                          \
+        if (!(expr)) { structstore::Callstack::throw_with_trace("assertion failed: " #expr); }     \
     } while (0)
 
 constexpr uint32_t const_hash(const char* input) {

--- a/src/include/structstore/stst_utils.hpp
+++ b/src/include/structstore/stst_utils.hpp
@@ -66,10 +66,10 @@ class NilLog {
         }                                                                                          \
     } while (0)
 
-constexpr uint64_t const_hash(const char* input) {
+constexpr uint32_t const_hash(const char* input) {
     // FNV1a hash of reversed string
-    return *input != 0 ? (const_hash(input + 1) ^ uint64_t((uint8_t) *input)) * 0x100000001b3ull
-                       : 0xcbf29ce484222325ull;
+    return *input != 0 ? (const_hash(input + 1) ^ uint32_t((uint8_t) *input)) * 0x01000193ul
+                       : 0x811C9DC5ul;
 }
 
 } // namespace structstore

--- a/src/mini_malloc.cpp
+++ b/src/mini_malloc.cpp
@@ -235,10 +235,7 @@ void* structstore::mm_allocate(mini_malloc* mm, size_t size) {
     int32_t left_size = node->size - size - ALLOC_NODE_SIZE;
     assert(left_size >= -ALLOC_NODE_SIZE);
     if (left_size >= ALIGN) {
-        if (left_size % ALIGN) {
-            left_size += ALIGN - size % ALIGN;
-            assert(left_size % ALIGN == 0);
-        }
+        assert(left_size % ALIGN == 0);
         size_index_type left_size_index = get_size_index_lower(left_size);
         memnode* new_node = (memnode*) (((byte*) node) + size + ALLOC_NODE_SIZE);
         new_node->size = left_size;

--- a/src/mini_malloc.cpp
+++ b/src/mini_malloc.cpp
@@ -165,10 +165,9 @@ static void prepend_free_node(mini_malloc* mm, memnode* node, size_index_type si
     attach_free_nodes(node, old_first_free);
 }
 
-mini_malloc* structstore::init_mini_malloc(void* buffer, size_t blocksize) {
-    mini_malloc* mm = (mini_malloc*) buffer;
+void structstore::init_mini_malloc(mini_malloc* mm, size_t blocksize) {
     static_assert((sizeof(mini_malloc) % ALIGN) == 0);
-    buffer = (byte*) buffer + sizeof(mini_malloc);
+    byte* buffer = (byte*) mm + sizeof(mini_malloc);
     blocksize -= sizeof(mini_malloc);
 
     // ensure alignment
@@ -200,7 +199,6 @@ mini_malloc* structstore::init_mini_malloc(void* buffer, size_t blocksize) {
     last_node->size = 0;
     set_next_free_node(get_free_nodes_head(mm, SIZES_COUNT - 1), block_node);
     assert((byte*) last_node + ALLOC_NODE_SIZE == (byte*) buffer + blocksize);
-    return mm;
 }
 
 void* structstore::mm_allocate(mini_malloc* mm, size_t size) {

--- a/src/structstore/__init__.py
+++ b/src/structstore/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 import pathlib
 

--- a/src/structstore_py.cpp
+++ b/src/structstore_py.cpp
@@ -51,9 +51,6 @@ NB_MODULE(MODULE_NAME, m) {
 
     // structstore::StructStore
     nb::class_<StructStore> cls = nb::class_<StructStore>{m, "StructStore"};
-    cls.def("__init__", [](StructStore* store) {
-        new (store) StructStore(static_alloc);
-    });
     py::ToPythonFn structstore_to_python_fn = [](const Field& field, py::ToPythonMode mode) -> nb::object {
         auto& store = field.get<StructStore>();
         return py::structstore_to_python(store, mode);

--- a/src/structstore_py.cpp
+++ b/src/structstore_py.cpp
@@ -1,6 +1,8 @@
 #include "structstore/stst_containers.hpp"
 #include "structstore/stst_field.hpp"
 #include "structstore/stst_py.hpp"
+#include "structstore/stst_shared.hpp"
+#include "structstore/stst_structstore.hpp"
 #include "structstore/stst_utils.hpp"
 
 #include <nanobind/nanobind.h>

--- a/src/structstore_py.cpp
+++ b/src/structstore_py.cpp
@@ -108,12 +108,11 @@ NB_MODULE(MODULE_NAME, m) {
     shcls.def(
             "__init__",
             [](StructStoreShared* s, const std::string& path, size_t size, bool reinit,
-               bool use_file, CleanupMode cleanup, uintptr_t target_addr) {
-                new (s) StructStoreShared{path,     size,    reinit,
-                                          use_file, cleanup, (void*) target_addr};
+               bool use_file, CleanupMode cleanup) {
+                new (s) StructStoreShared{path, size, reinit, use_file, cleanup};
             },
             nb::arg("path"), nb::arg("size") = 4096, nb::arg("reinit") = false,
-            nb::arg("use_file") = false, nb::arg("cleanup") = IF_LAST, nb::arg("target_addr") = 0);
+            nb::arg("use_file") = false, nb::arg("cleanup") = IF_LAST);
     shcls.def(
             "__init__",
             [](StructStoreShared* s, int fd, bool init) { new (s) StructStoreShared{fd, init}; },
@@ -131,9 +130,6 @@ NB_MODULE(MODULE_NAME, m) {
                 return res;
             },
             nb::arg("block") = true);
-    shcls.def("addr", [](StructStoreShared& shs) {
-        return uintptr_t(shs.addr());
-    });
     shcls.def("to_bytes", [](StructStoreShared& shs) {
         return nb::bytes((const char*) shs.addr(), shs.size());
     });

--- a/src/structstore_py.cpp
+++ b/src/structstore_py.cpp
@@ -15,6 +15,8 @@ namespace nb = nanobind;
 NB_MODULE(MODULE_NAME, m) {
     // API types:
 
+    py::SimpleNamespace = nb::module_::import_("types").attr("SimpleNamespace");
+
     nb::class_<ScopedFieldLock<false>>(m, "ScopedReadLock")
             .def("__enter__", [](ScopedFieldLock<false>&) {})
             .def(

--- a/src/stst_alloc.cpp
+++ b/src/stst_alloc.cpp
@@ -2,8 +2,15 @@
 
 using namespace structstore;
 
+struct ManagedMalloc {
+    void* data;
+    ManagedMalloc(size_t size) : data{std::malloc(size)} {}
+    ~ManagedMalloc() { std::free(data); }
+};
+
 static constexpr size_t static_alloc_size = 1 << 20;
-SharedAlloc structstore::static_alloc(std::malloc(static_alloc_size), static_alloc_size);
+ManagedMalloc static_alloc_data{static_alloc_size};
+SharedAlloc structstore::static_alloc{static_alloc_data.data, static_alloc_size};
 
 SharedAlloc::SharedAlloc(void* buffer, size_t size)
     : mm{(mini_malloc*) buffer}, blocksize{size}, string_storage{nullptr} {

--- a/src/stst_alloc.cpp
+++ b/src/stst_alloc.cpp
@@ -1,20 +1,28 @@
 #include "structstore/stst_alloc.hpp"
+#include "structstore/stst_utils.hpp"
+#include <limits>
 
 using namespace structstore;
 
-struct ManagedMalloc {
-    void* data;
-    ManagedMalloc(size_t size) : data{std::malloc(size)} {}
-    ~ManagedMalloc() { std::free(data); }
+struct ManagedSharedAlloc {
+    SharedAlloc* sh_alloc;
+    ManagedSharedAlloc(size_t size) {
+        size_t sh_alloc_size = sizeof(SharedAlloc);
+        if (sh_alloc_size % 8) { sh_alloc_size += 8 - sh_alloc_size % 8; }
+        uint8_t* data = (uint8_t*) std::malloc(size);
+        sh_alloc = new (data) SharedAlloc(data + sh_alloc_size, size - sh_alloc_size);
+    }
+    ~ManagedSharedAlloc() { std::free(sh_alloc); }
 };
 
 static constexpr size_t static_alloc_size = 1 << 20;
-ManagedMalloc static_alloc_data{static_alloc_size};
-SharedAlloc structstore::static_alloc{static_alloc_data.data, static_alloc_size};
+static ManagedSharedAlloc managed_static_alloc{static_alloc_size};
+SharedAlloc& structstore::static_alloc = *managed_static_alloc.sh_alloc;
 
 SharedAlloc::SharedAlloc(void* buffer, size_t size)
-    : mm{(mini_malloc*) buffer}, blocksize{size}, string_storage{nullptr} {
+    : mm{(mini_malloc*) buffer}, blocksize{(uint32_t) size}, string_storage{nullptr} {
     if (buffer == nullptr) { return; }
+    stst_assert(size < (1ull << 31));
     init_mini_malloc(mm.get(), size);
     string_storage = allocate<StringStorage>();
     new (string_storage.get()) StringStorage(*this);

--- a/src/stst_alloc.cpp
+++ b/src/stst_alloc.cpp
@@ -27,7 +27,7 @@ SharedAlloc::~SharedAlloc() noexcept(false) {
 }
 
 const shr_string* StringStorage::internalize(const std::string& str) {
-    shr_string str_{str, StlAllocator<>{sh_alloc}};
+    shr_string str_{str, StlAllocator<>{*sh_alloc}};
     {
         ScopedLock<false> lock{mutex};
         auto it = data.find(str_);
@@ -40,7 +40,7 @@ const shr_string* StringStorage::internalize(const std::string& str) {
 
 const shr_string* StringStorage::get(const std::string& str) {
     ScopedLock<false> lock{mutex};
-    shr_string str_{str, StlAllocator<>{sh_alloc}};
+    shr_string str_{str, StlAllocator<>{*sh_alloc}};
     auto it = data.find(str_);
     if (it != data.end()) { return &*it; }
     return nullptr;

--- a/src/stst_alloc.cpp
+++ b/src/stst_alloc.cpp
@@ -3,36 +3,38 @@
 using namespace structstore;
 
 static constexpr size_t static_alloc_size = 1 << 20;
-MiniMalloc structstore::static_alloc(std::malloc(static_alloc_size), static_alloc_size);
+SharedAlloc structstore::static_alloc(std::malloc(static_alloc_size), static_alloc_size);
 
-MiniMalloc::MiniMalloc(void* buffer, size_t size)
-    : mm{nullptr}, buffer{(byte*) buffer}, blocksize{size}, string_storage{nullptr} {
+SharedAlloc::SharedAlloc(void* buffer, size_t size)
+    : mm{(mini_malloc*) buffer}, blocksize{size}, string_storage{nullptr} {
     if (buffer == nullptr) { return; }
-    mm = init_mini_malloc(buffer, size);
-    string_storage = (StringStorage*) allocate(sizeof(StringStorage));
-    new (string_storage) StringStorage(*this);
+    init_mini_malloc(mm.get(), size);
+    string_storage = allocate<StringStorage>();
+    new (string_storage.get()) StringStorage(*this);
 }
 
-MiniMalloc::~MiniMalloc() noexcept(false) {
+SharedAlloc::~SharedAlloc() noexcept(false) {
     string_storage->~StringStorage();
-    deallocate(string_storage);
-    mm_assert_all_freed(mm);
+    deallocate(string_storage.get());
+    mm_assert_all_freed(mm.get());
 }
 
 const shr_string* StringStorage::internalize(const std::string& str) {
-    shr_string str_{str, StlAllocator<int>{mm_alloc}};
+    shr_string str_{str, StlAllocator<>{sh_alloc}};
     {
         ScopedLock<false> lock{mutex};
         auto it = data.find(str_);
         if (it != data.end()) { return &*it; }
     }
     ScopedLock<true> lock{mutex};
-    return &*data.insert(str_).first;
+    const shr_string& found_str = *data.insert(str_).first;
+    return &found_str;
 }
 
 const shr_string* StringStorage::get(const std::string& str) {
     ScopedLock<false> lock{mutex};
-    auto it = data.find(shr_string{str, StlAllocator<int>{mm_alloc}});
+    shr_string str_{str, StlAllocator<>{sh_alloc}};
+    auto it = data.find(str_);
     if (it != data.end()) { return &*it; }
     return nullptr;
 }

--- a/src/stst_containers.cpp
+++ b/src/stst_containers.cpp
@@ -8,9 +8,9 @@ using namespace structstore;
 
 const TypeInfo& String::type_info = typing::register_type<String>("structstore::String");
 
-void String::check(const MiniMalloc* mm_alloc) const {
+void String::check(const SharedAlloc* sh_alloc) const {
     CallstackEntry entry{"structstore::String::check()"};
-    if (mm_alloc && !empty()) { stst_assert(mm_alloc->is_owned(data())); }
+    if (sh_alloc && !empty()) { stst_assert(sh_alloc->is_owned(data())); }
 }
 
 String& String::operator=(const std::string& value) {
@@ -38,15 +38,15 @@ YAML::Node List::to_yaml() const {
     return node;
 }
 
-void List::check(const MiniMalloc* mm_alloc) const {
+void List::check(const SharedAlloc* sh_alloc) const {
     CallstackEntry entry{"structstore::List::check()"};
-    if (mm_alloc) {
-        stst_assert(&this->mm_alloc == mm_alloc);
+    if (sh_alloc) {
+        stst_assert(&this->sh_alloc == sh_alloc);
     } else {
         // use our own reference instead
-        mm_alloc = &this->mm_alloc;
+        sh_alloc = &this->sh_alloc;
     }
-    for (const Field& field: data) { field.check(*mm_alloc, *this); }
+    for (const Field& field: data) { field.check(*sh_alloc, *this); }
 }
 
 bool List::operator==(const List& other) const {
@@ -71,15 +71,15 @@ YAML::Node Matrix::to_yaml() const {
     throw std::runtime_error("serialize_yaml_fn not implemented for structstore::Matrix");
 }
 
-void Matrix::check(const MiniMalloc* mm_alloc) const {
+void Matrix::check(const SharedAlloc* sh_alloc) const {
     CallstackEntry entry{"structstore::Matrix::check()"};
-    if (mm_alloc) {
-        stst_assert(&this->mm_alloc == mm_alloc);
+    if (sh_alloc) {
+        stst_assert(&this->sh_alloc == sh_alloc);
     } else {
         // use our own reference instead
-        mm_alloc = &this->mm_alloc;
+        sh_alloc = &this->sh_alloc;
     }
-    if (_data) { stst_assert(mm_alloc->is_owned(_data)); }
+    if (_data) { stst_assert(sh_alloc->is_owned(_data)); }
 }
 
 bool Matrix::operator==(const Matrix& other) const {

--- a/src/stst_containers.cpp
+++ b/src/stst_containers.cpp
@@ -41,10 +41,10 @@ YAML::Node List::to_yaml() const {
 void List::check(const SharedAlloc* sh_alloc) const {
     CallstackEntry entry{"structstore::List::check()"};
     if (sh_alloc) {
-        stst_assert(&this->sh_alloc == sh_alloc);
+        stst_assert(this->sh_alloc == sh_alloc);
     } else {
         // use our own reference instead
-        sh_alloc = &this->sh_alloc;
+        sh_alloc = this->sh_alloc.get();
     }
     for (const Field& field: data) { field.check(*sh_alloc, *this); }
 }
@@ -74,12 +74,12 @@ YAML::Node Matrix::to_yaml() const {
 void Matrix::check(const SharedAlloc* sh_alloc) const {
     CallstackEntry entry{"structstore::Matrix::check()"};
     if (sh_alloc) {
-        stst_assert(&this->sh_alloc == sh_alloc);
+        stst_assert(this->sh_alloc == sh_alloc);
     } else {
         // use our own reference instead
-        sh_alloc = &this->sh_alloc;
+        sh_alloc = this->sh_alloc.get();
     }
-    if (_data) { stst_assert(sh_alloc->is_owned(_data)); }
+    if (_data) { stst_assert(sh_alloc->is_owned(_data.get())); }
 }
 
 bool Matrix::operator==(const Matrix& other) const {

--- a/src/stst_field.cpp
+++ b/src/stst_field.cpp
@@ -8,12 +8,12 @@ using namespace structstore;
 
 void Field::to_text(std::ostream& os) const {
     const auto& type_info = typing::get_type(type_hash);
-    type_info.serialize_text_fn(os, data);
+    type_info.serialize_text_fn(os, data.get());
 }
 
 YAML::Node Field::to_yaml() const {
     const auto& type_info = typing::get_type(type_hash);
-    return type_info.serialize_yaml_fn(data);
+    return type_info.serialize_yaml_fn(data.get());
 }
 
 void Field::construct_copy_from(SharedAlloc& sh_alloc, const Field& other,
@@ -22,8 +22,8 @@ void Field::construct_copy_from(SharedAlloc& sh_alloc, const Field& other,
     type_hash = other.type_hash;
     const auto& type_info = typing::get_type(type_hash);
     data = sh_alloc.allocate(type_info.size);
-    type_info.constructor_fn(sh_alloc, data, parent_field);
-    type_info.copy_fn(sh_alloc, data, other.data);
+    type_info.constructor_fn(sh_alloc, data.get(), parent_field);
+    type_info.copy_fn(sh_alloc, data.get(), other.data.get());
 }
 
 void Field::copy_from(SharedAlloc& sh_alloc, const Field& other) {
@@ -32,7 +32,7 @@ void Field::copy_from(SharedAlloc& sh_alloc, const Field& other) {
         throw std::runtime_error("copying field with different type");
     }
     const auto& type_info = typing::get_type(type_hash);
-    type_info.copy_fn(sh_alloc, data, other.data);
+    type_info.copy_fn(sh_alloc, data.get(), other.data.get());
 }
 
 void Field::move_from(Field& other) {
@@ -45,9 +45,9 @@ void Field::check(const SharedAlloc& sh_alloc, const FieldTypeBase& parent_field
     CallstackEntry entry{"structstore::Field::check()"};
     stst_assert(sh_alloc.is_owned(this));
     if (data) {
-        stst_assert(sh_alloc.is_owned(data));
+        stst_assert(sh_alloc.is_owned(data.get()));
         const TypeInfo& type_info = typing::get_type(type_hash);
-        type_info.check_fn(sh_alloc, data, parent_field);
+        type_info.check_fn(sh_alloc, data.get(), parent_field);
     }
 }
 

--- a/src/stst_field.cpp
+++ b/src/stst_field.cpp
@@ -16,23 +16,23 @@ YAML::Node Field::to_yaml() const {
     return type_info.serialize_yaml_fn(data);
 }
 
-void Field::construct_copy_from(MiniMalloc& mm_alloc, const Field& other,
+void Field::construct_copy_from(SharedAlloc& sh_alloc, const Field& other,
                                 const FieldTypeBase* parent_field) {
     assert_empty();
     type_hash = other.type_hash;
     const auto& type_info = typing::get_type(type_hash);
-    data = mm_alloc.allocate(type_info.size);
-    type_info.constructor_fn(mm_alloc, data, parent_field);
-    type_info.copy_fn(mm_alloc, data, other.data);
+    data = sh_alloc.allocate(type_info.size);
+    type_info.constructor_fn(sh_alloc, data, parent_field);
+    type_info.copy_fn(sh_alloc, data, other.data);
 }
 
-void Field::copy_from(MiniMalloc& mm_alloc, const Field& other) {
+void Field::copy_from(SharedAlloc& sh_alloc, const Field& other) {
     assert_nonempty();
     if (type_hash != other.type_hash) {
         throw std::runtime_error("copying field with different type");
     }
     const auto& type_info = typing::get_type(type_hash);
-    type_info.copy_fn(mm_alloc, data, other.data);
+    type_info.copy_fn(sh_alloc, data, other.data);
 }
 
 void Field::move_from(Field& other) {
@@ -41,13 +41,13 @@ void Field::move_from(Field& other) {
     std::swap(data, other.data);
 }
 
-void Field::check(const MiniMalloc& mm_alloc, const FieldTypeBase& parent_field) const {
+void Field::check(const SharedAlloc& sh_alloc, const FieldTypeBase& parent_field) const {
     CallstackEntry entry{"structstore::Field::check()"};
-    stst_assert(mm_alloc.is_owned(this));
+    stst_assert(sh_alloc.is_owned(this));
     if (data) {
-        stst_assert(mm_alloc.is_owned(data));
+        stst_assert(sh_alloc.is_owned(data));
         const TypeInfo& type_info = typing::get_type(type_hash);
-        type_info.check_fn(mm_alloc, data, parent_field);
+        type_info.check_fn(sh_alloc, data, parent_field);
     }
 }
 

--- a/src/stst_field.cpp
+++ b/src/stst_field.cpp
@@ -6,14 +6,14 @@
 
 using namespace structstore;
 
-void Field::to_text(std::ostream& os) const {
+void FieldView::to_text(std::ostream& os) const {
     const auto& type_info = typing::get_type(type_hash);
-    type_info.serialize_text_fn(os, data.get());
+    type_info.serialize_text_fn(os, data);
 }
 
-YAML::Node Field::to_yaml() const {
+YAML::Node FieldView::to_yaml() const {
     const auto& type_info = typing::get_type(type_hash);
-    return type_info.serialize_yaml_fn(data.get());
+    return type_info.serialize_yaml_fn(data);
 }
 
 void Field::construct_copy_from(SharedAlloc& sh_alloc, const Field& other,
@@ -41,18 +41,14 @@ void Field::move_from(Field& other) {
     std::swap(data, other.data);
 }
 
-void Field::check(const SharedAlloc& sh_alloc, const FieldTypeBase& parent_field) const {
-    CallstackEntry entry{"structstore::Field::check()"};
-    stst_assert(sh_alloc.is_owned(this));
+void FieldView::check(const SharedAlloc& sh_alloc, const FieldTypeBase& parent_field) const {
+    CallstackEntry entry{"structstore::FieldView::check()"};
     if (data) {
-        stst_assert(sh_alloc.is_owned(data.get()));
+        stst_assert(sh_alloc.is_owned(data));
         const TypeInfo& type_info = typing::get_type(type_hash);
-        type_info.check_fn(sh_alloc, data.get(), parent_field);
+        type_info.check_fn(sh_alloc, data, parent_field);
     }
 }
-
-template<>
-FieldView::FieldView(StructStoreShared& store) : field{&*store} {}
 
 template<>
 ::structstore::String& FieldAccess<false>::get_str() {

--- a/src/stst_fieldmap.cpp
+++ b/src/stst_fieldmap.cpp
@@ -22,14 +22,14 @@ bool FieldMapBase::operator==(const FieldMapBase& other) const {
 }
 
 Field* FieldMapBase::try_get_field(const std::string& name) {
-    const shr_string* name_ = sh_alloc.strings().get(name);
+    const shr_string* name_ = sh_alloc->strings().get(name);
     auto it = fields.find(name_);
     if (it == fields.end()) { return nullptr; }
     return &it->second;
 }
 
 const Field* FieldMapBase::try_get_field(const std::string& name) const {
-    const shr_string* name_ = sh_alloc.strings().get(name);
+    const shr_string* name_ = sh_alloc->strings().get(name);
     auto it = fields.find(name_);
     if (it == fields.end()) { return nullptr; }
     return &it->second;
@@ -38,7 +38,7 @@ const Field* FieldMapBase::try_get_field(const std::string& name) const {
 void FieldMapBase::to_text(std::ostream& os) const {
     STST_LOG_DEBUG() << "serializing StructStore at " << this;
     os << "{";
-    for (const shr_string* name: slots) {
+    for (shr_string_ptr name: slots) {
         STST_LOG_DEBUG() << "field " << *name << " is at " << &fields.at(name);
         os << '"' << *name << "\":";
         fields.at(name).to_text(os);
@@ -49,26 +49,26 @@ void FieldMapBase::to_text(std::ostream& os) const {
 
 YAML::Node FieldMapBase::to_yaml() const {
     YAML::Node root(YAML::NodeType::Map);
-    for (const shr_string* name: slots) { root[name->c_str()] = fields.at(name).to_yaml(); }
+    for (shr_string_ptr name: slots) { root[name->c_str()] = fields.at(name).to_yaml(); }
     return root;
 }
 
 void FieldMapBase::check(const SharedAlloc* sh_alloc, const FieldTypeBase& parent_field) const {
     CallstackEntry entry{"structstore::FieldMap::check()"};
     if (sh_alloc) {
-        stst_assert(&this->sh_alloc == sh_alloc);
+        stst_assert(this->sh_alloc.get() == sh_alloc);
     } else {
         // use our own reference instead
-        sh_alloc = &this->sh_alloc;
+        sh_alloc = this->sh_alloc.get();
     }
     // this could be allocated on regular stack/heap if the owning StructStore is not in shared mem
     stst_assert(sh_alloc == &static_alloc || sh_alloc->is_owned(this));
     if (slots.size() != fields.size()) {
         throw std::runtime_error("in FieldMap: slots and fields with different size");
     }
-    for (const shr_string* str: slots) { stst_assert(sh_alloc->is_owned(str)); }
+    for (shr_string_ptr str: slots) { stst_assert(sh_alloc->is_owned(str.get())); }
     for (const auto& [key, value]: fields) {
-        stst_assert(sh_alloc->is_owned(key));
+        stst_assert(sh_alloc->is_owned(key.get()));
         value.check(*sh_alloc, parent_field);
     }
 }
@@ -82,7 +82,7 @@ void FieldMap<false>::copy_from_unmanaged(const FieldMap<false>& other) {
     }
     for (auto it1 = get_slots().begin(), it2 = other.slots.begin(); it1 != slots.end();
          ++it1, ++it2) {
-        fields.at(*it1).copy_from(sh_alloc, other.get_fields().at(*it2));
+        fields.at(*it1).copy_from(*sh_alloc, other.fields.at(*it2));
     }
 }
 
@@ -92,19 +92,19 @@ void FieldMap<true>::copy_from_managed(const FieldMap<true>& other,
     // managed copy: clear and insert the other contents
     STST_LOG_DEBUG() << "copying FieldMap from " << &other << " into " << this;
     clear();
-    for (const shr_string* str: other.get_slots()) {
-        const shr_string* name_int = sh_alloc.strings().internalize(std::string(*str));
+    for (shr_string_ptr str: other.get_slots()) {
+        const shr_string* name_int = sh_alloc->strings().internalize(std::string(*str));
         slots.emplace_back(name_int);
         Field& field = fields.emplace(name_int, Field{}).first->second;
-        field.construct_copy_from(sh_alloc, other.get_fields().at(str), parent_field);
+        field.construct_copy_from(*sh_alloc, other.fields.at(str), parent_field);
     }
 }
 
 template<>
 Field& FieldMap<true>::get_or_insert(const std::string& name) {
-    auto it = fields.find(sh_alloc.strings().get(name));
+    auto it = fields.find(sh_alloc->strings().get(name));
     if (it == fields.end()) {
-        const shr_string* name_int = sh_alloc.strings().internalize(name);
+        const shr_string* name_int = sh_alloc->strings().internalize(name);
         it = fields.emplace(name_int, Field{}).first;
         slots.emplace_back(name_int);
     }

--- a/src/stst_fieldmap.cpp
+++ b/src/stst_fieldmap.cpp
@@ -7,7 +7,9 @@ using namespace structstore;
 bool FieldMapBase::equal_slots(const FieldMapBase& other) const {
     if (slots.size() != other.slots.size()) return false;
     for (auto it1 = slots.begin(), it2 = other.slots.begin(); it1 != slots.end(); ++it1, ++it2) {
-        if (**it1 != **it2) { return false; }
+        if (*sh_alloc->strings().get(*it1) != *other.sh_alloc->strings().get(*it2)) {
+            return false;
+        }
     }
     return true;
 }
@@ -15,22 +17,24 @@ bool FieldMapBase::equal_slots(const FieldMapBase& other) const {
 bool FieldMapBase::operator==(const FieldMapBase& other) const {
     if (slots.size() != other.slots.size()) return false;
     for (auto it1 = slots.begin(), it2 = other.slots.begin(); it1 != slots.end(); ++it1, ++it2) {
-        if (**it1 != **it2) { return false; }
+        if (*sh_alloc->strings().get(*it1) != *other.sh_alloc->strings().get(*it2)) {
+            return false;
+        }
         if (fields.at(*it1) != other.fields.at(*it2)) { return false; }
     }
     return true;
 }
 
 Field* FieldMapBase::try_get_field(const std::string& name) {
-    const shr_string* name_ = sh_alloc->strings().get(name);
-    auto it = fields.find(name_);
+    shr_string_idx name_idx = sh_alloc->strings().get_idx(name, *sh_alloc);
+    auto it = fields.find(name_idx);
     if (it == fields.end()) { return nullptr; }
     return &it->second;
 }
 
 const Field* FieldMapBase::try_get_field(const std::string& name) const {
-    const shr_string* name_ = sh_alloc->strings().get(name);
-    auto it = fields.find(name_);
+    shr_string_idx name_idx = sh_alloc->strings().get_idx(name, *sh_alloc);
+    auto it = fields.find(name_idx);
     if (it == fields.end()) { return nullptr; }
     return &it->second;
 }
@@ -38,10 +42,11 @@ const Field* FieldMapBase::try_get_field(const std::string& name) const {
 void FieldMapBase::to_text(std::ostream& os) const {
     STST_LOG_DEBUG() << "serializing StructStore at " << this;
     os << "{";
-    for (shr_string_ptr name: slots) {
-        STST_LOG_DEBUG() << "field " << *name << " is at " << &fields.at(name);
+    for (shr_string_idx name_idx: slots) {
+        const shr_string* name = sh_alloc->strings().get(name_idx);
+        STST_LOG_DEBUG() << "field " << *name << " is at " << &fields.at(name_idx);
         os << '"' << *name << "\":";
-        fields.at(name).to_text(os);
+        fields.at(name_idx).to_text(os);
         os << ",";
     }
     os << "}";
@@ -49,7 +54,10 @@ void FieldMapBase::to_text(std::ostream& os) const {
 
 YAML::Node FieldMapBase::to_yaml() const {
     YAML::Node root(YAML::NodeType::Map);
-    for (shr_string_ptr name: slots) { root[name->c_str()] = fields.at(name).to_yaml(); }
+    for (shr_string_idx name_idx: slots) {
+        const shr_string* name = sh_alloc->strings().get(name_idx);
+        root[name->c_str()] = fields.at(name_idx).to_yaml();
+    }
     return root;
 }
 
@@ -66,9 +74,11 @@ void FieldMapBase::check(const SharedAlloc* sh_alloc, const FieldTypeBase& paren
     if (slots.size() != fields.size()) {
         throw std::runtime_error("in FieldMap: slots and fields with different size");
     }
-    for (shr_string_ptr str: slots) { stst_assert(sh_alloc->is_owned(str.get())); }
-    for (const auto& [key, value]: fields) {
-        stst_assert(sh_alloc->is_owned(key.get()));
+    for (shr_string_idx idx: slots) {
+        stst_assert(sh_alloc->is_owned(sh_alloc->strings().get(idx)));
+    }
+    for (const auto& [idx, value]: fields) {
+        stst_assert(sh_alloc->is_owned(sh_alloc->strings().get(idx)));
         value.check(*sh_alloc, parent_field);
     }
 }
@@ -92,21 +102,20 @@ void FieldMap<true>::copy_from_managed(const FieldMap<true>& other,
     // managed copy: clear and insert the other contents
     STST_LOG_DEBUG() << "copying FieldMap from " << &other << " into " << this;
     clear();
-    for (shr_string_ptr str: other.get_slots()) {
-        const shr_string* name_int = sh_alloc->strings().internalize(std::string(*str));
-        slots.emplace_back(name_int);
-        Field& field = fields.emplace(name_int, Field{}).first->second;
-        field.construct_copy_from(*sh_alloc, other.fields.at(str), parent_field);
+    for (shr_string_idx name_idx_other: other.get_slots()) {
+        const shr_string* name_other = other.sh_alloc->strings().get(name_idx_other);
+        shr_string_idx name_idx =
+                sh_alloc->strings().internalize(std::string(*name_other), *sh_alloc);
+        slots.emplace_back(name_idx);
+        Field& field = fields.emplace(name_idx, Field{}).first->second;
+        field.construct_copy_from(*sh_alloc, other.fields.at(name_idx_other), parent_field);
     }
 }
 
 template<>
 Field& FieldMap<true>::get_or_insert(const std::string& name) {
-    auto it = fields.find(sh_alloc->strings().get(name));
-    if (it == fields.end()) {
-        const shr_string* name_int = sh_alloc->strings().internalize(name);
-        it = fields.emplace(name_int, Field{}).first;
-        slots.emplace_back(name_int);
-    }
+    shr_string_idx name_idx = sh_alloc->strings().internalize(name, *sh_alloc);
+    auto [it, inserted] = fields.emplace(name_idx, Field{});
+    if (inserted) { slots.emplace_back(name_idx); }
     return it->second;
 }

--- a/src/stst_fieldmap.cpp
+++ b/src/stst_fieldmap.cpp
@@ -22,14 +22,14 @@ bool FieldMapBase::operator==(const FieldMapBase& other) const {
 }
 
 Field* FieldMapBase::try_get_field(const std::string& name) {
-    const shr_string* name_ = mm_alloc.strings().get(name);
+    const shr_string* name_ = sh_alloc.strings().get(name);
     auto it = fields.find(name_);
     if (it == fields.end()) { return nullptr; }
     return &it->second;
 }
 
 const Field* FieldMapBase::try_get_field(const std::string& name) const {
-    const shr_string* name_ = mm_alloc.strings().get(name);
+    const shr_string* name_ = sh_alloc.strings().get(name);
     auto it = fields.find(name_);
     if (it == fields.end()) { return nullptr; }
     return &it->second;
@@ -53,23 +53,23 @@ YAML::Node FieldMapBase::to_yaml() const {
     return root;
 }
 
-void FieldMapBase::check(const MiniMalloc* mm_alloc, const FieldTypeBase& parent_field) const {
+void FieldMapBase::check(const SharedAlloc* sh_alloc, const FieldTypeBase& parent_field) const {
     CallstackEntry entry{"structstore::FieldMap::check()"};
-    if (mm_alloc) {
-        stst_assert(&this->mm_alloc == mm_alloc);
+    if (sh_alloc) {
+        stst_assert(&this->sh_alloc == sh_alloc);
     } else {
         // use our own reference instead
-        mm_alloc = &this->mm_alloc;
+        sh_alloc = &this->sh_alloc;
     }
     // this could be allocated on regular stack/heap if the owning StructStore is not in shared mem
-    stst_assert(mm_alloc == &static_alloc || mm_alloc->is_owned(this));
+    stst_assert(sh_alloc == &static_alloc || sh_alloc->is_owned(this));
     if (slots.size() != fields.size()) {
         throw std::runtime_error("in FieldMap: slots and fields with different size");
     }
-    for (const shr_string* str: slots) { stst_assert(mm_alloc->is_owned(str)); }
+    for (const shr_string* str: slots) { stst_assert(sh_alloc->is_owned(str)); }
     for (const auto& [key, value]: fields) {
-        stst_assert(mm_alloc->is_owned(key));
-        value.check(*mm_alloc, parent_field);
+        stst_assert(sh_alloc->is_owned(key));
+        value.check(*sh_alloc, parent_field);
     }
 }
 
@@ -82,7 +82,7 @@ void FieldMap<false>::copy_from_unmanaged(const FieldMap<false>& other) {
     }
     for (auto it1 = get_slots().begin(), it2 = other.slots.begin(); it1 != slots.end();
          ++it1, ++it2) {
-        fields.at(*it1).copy_from(mm_alloc, other.get_fields().at(*it2));
+        fields.at(*it1).copy_from(sh_alloc, other.get_fields().at(*it2));
     }
 }
 
@@ -93,18 +93,18 @@ void FieldMap<true>::copy_from_managed(const FieldMap<true>& other,
     STST_LOG_DEBUG() << "copying FieldMap from " << &other << " into " << this;
     clear();
     for (const shr_string* str: other.get_slots()) {
-        const shr_string* name_int = mm_alloc.strings().internalize(std::string(*str));
+        const shr_string* name_int = sh_alloc.strings().internalize(std::string(*str));
         slots.emplace_back(name_int);
         Field& field = fields.emplace(name_int, Field{}).first->second;
-        field.construct_copy_from(mm_alloc, other.get_fields().at(str), parent_field);
+        field.construct_copy_from(sh_alloc, other.get_fields().at(str), parent_field);
     }
 }
 
 template<>
 Field& FieldMap<true>::get_or_insert(const std::string& name) {
-    auto it = fields.find(mm_alloc.strings().get(name));
+    auto it = fields.find(sh_alloc.strings().get(name));
     if (it == fields.end()) {
-        const shr_string* name_int = mm_alloc.strings().internalize(name);
+        const shr_string* name_int = sh_alloc.strings().internalize(name);
         it = fields.emplace(name_int, Field{}).first;
         slots.emplace_back(name_int);
     }

--- a/src/stst_lock.cpp
+++ b/src/stst_lock.cpp
@@ -78,6 +78,22 @@ void SpinMutex::write_unlock() {
     STST_LOG_DEBUG() << "write unlocked " << this;
 }
 
+void SpinMutex::read_or_write_lock() {
+    if (write_lock_tid == tid) {
+        write_lock();
+    } else {
+        read_lock();
+    }
+}
+
+void SpinMutex::read_or_write_unlock() {
+    if (write_lock_tid == tid) {
+        write_unlock();
+    } else {
+        read_unlock();
+    }
+}
+
 template<>
 ScopedLock<false>::ScopedLock(SpinMutex& mutex) : mutex(&mutex) {
     mutex.read_lock();

--- a/src/stst_lock.cpp
+++ b/src/stst_lock.cpp
@@ -39,7 +39,7 @@ void SpinMutex::read_lock() {
     if (write_lock_tid == tid) {
         throw std::runtime_error("trying to acquire read lock while current thread has write lock");
     }
-    int32_t v;
+    int16_t v;
     TIMEOUT_CHECK_INIT
     do {
         while ((v = level.load(std::memory_order_relaxed)) < 0) { TIMEOUT_CHECK("read lock"); }
@@ -49,14 +49,14 @@ void SpinMutex::read_lock() {
 
 void SpinMutex::read_unlock() {
     STST_LOG_DEBUG() << "read unlocking " << this;
-    int32_t v = level.load(std::memory_order_relaxed);
+    int16_t v = level.load(std::memory_order_relaxed);
     while (!level.compare_exchange_weak(v, v - 1, std::memory_order_acquire));
     STST_LOG_DEBUG() << "read unlocked at " << this << " at level " << v - 1;
 }
 
 void SpinMutex::write_lock() {
     STST_LOG_DEBUG() << "write locking " << this;
-    int32_t v;
+    int16_t v;
     if (write_lock_tid == tid) {
         v = level.load(std::memory_order_relaxed);
         level.store(v - 1, std::memory_order_relaxed);
@@ -72,7 +72,7 @@ void SpinMutex::write_lock() {
 }
 
 void SpinMutex::write_unlock() {
-    int32_t v = level.load(std::memory_order_relaxed);
+    int16_t v = level.load(std::memory_order_relaxed);
     level.store(v + 1, std::memory_order_release);
     if (v + 1 == 0) { write_lock_tid = 0; }
     STST_LOG_DEBUG() << "write unlocked " << this;

--- a/src/stst_py.cpp
+++ b/src/stst_py.cpp
@@ -30,7 +30,7 @@ const py::PyType& py::get_py_type(uint64_t type_hash) {
 __attribute__((__visibility__("default"))) nb::object
 py::field_map_to_python(const FieldMapBase& field_map, py::ToPythonMode mode) {
     auto dict = nb::dict();
-    for (const shr_string* str: field_map.get_slots()) {
+    for (shr_string_ptr str: field_map.get_slots()) {
         auto key = nb::str(str->c_str());
         if (mode == py::ToPythonMode::RECURSIVE) {
             dict[key] = py::to_python(field_map.at(str), py::ToPythonMode::RECURSIVE);
@@ -49,7 +49,7 @@ py::field_map_from_python(FieldMap<false>& field_map, const nb::dict& dict,
         Callstack::throw_with_trace<std::runtime_error>(
                 "cannot copy dict with wrong fields into struct");
     }
-    for (const shr_string* str: field_map.get_slots()) {
+    for (shr_string_ptr str: field_map.get_slots()) {
         std::string key_str = str->c_str();
         py::set_field(field_map, key_str, dict[str->c_str()], parent_field);
     }

--- a/src/stst_py.cpp
+++ b/src/stst_py.cpp
@@ -32,12 +32,12 @@ const py::PyType& py::get_py_type(uint64_t type_hash) {
 __attribute__((__visibility__("default"))) nb::object
 py::field_map_to_python(const FieldMapBase& field_map, py::ToPythonMode mode) {
     auto obj = SimpleNamespace();
-    for (shr_string_ptr str: field_map.get_slots()) {
-        auto key = nb::str(str->c_str());
+    for (shr_string_idx str_idx: field_map.get_slots()) {
+        auto key = nb::str(field_map.get_alloc().strings().get(str_idx)->c_str());
         if (mode == py::ToPythonMode::RECURSIVE) {
-            nb::setattr(obj, key, py::to_python(field_map.at(str), py::ToPythonMode::RECURSIVE));
+            nb::setattr(obj, key, py::to_python(field_map.at(str_idx), py::ToPythonMode::RECURSIVE));
         } else { // non-recursive convert
-            nb::setattr(obj, key, py::to_python_cast(field_map.at(str)));
+            nb::setattr(obj, key, py::to_python_cast(field_map.at(str_idx)));
         }
     }
     return obj;
@@ -51,9 +51,9 @@ py::field_map_from_python(FieldMap<false>& field_map, const nb::dict& dict,
         Callstack::throw_with_trace<std::runtime_error>(
                 "cannot copy dict with wrong fields into struct");
     }
-    for (shr_string_ptr str: field_map.get_slots()) {
-        std::string key_str = str->c_str();
-        py::set_field(field_map, key_str, dict[str->c_str()], parent_field);
+    for (shr_string_idx str_idx: field_map.get_slots()) {
+        std::string key_str = field_map.get_alloc().strings().get(str_idx)->c_str();
+        py::set_field(field_map, key_str, dict[key_str.c_str()], parent_field);
     }
 }
 

--- a/src/stst_py.cpp
+++ b/src/stst_py.cpp
@@ -12,7 +12,6 @@ using namespace structstore;
 
 namespace nb = nanobind;
 
-__attribute__((__visibility__("default")))
 nb::object py::SimpleNamespace;
 
 std::unordered_map<uint64_t, const py::PyType>& py::get_py_types() {

--- a/src/stst_py.cpp
+++ b/src/stst_py.cpp
@@ -12,6 +12,9 @@ using namespace structstore;
 
 namespace nb = nanobind;
 
+__attribute__((__visibility__("default")))
+nb::object py::SimpleNamespace;
+
 std::unordered_map<uint64_t, const py::PyType>& py::get_py_types() {
     static auto* from_python_fns = new std::unordered_map<uint64_t, const py::PyType>();
     return *from_python_fns;
@@ -29,16 +32,16 @@ const py::PyType& py::get_py_type(uint64_t type_hash) {
 
 __attribute__((__visibility__("default"))) nb::object
 py::field_map_to_python(const FieldMapBase& field_map, py::ToPythonMode mode) {
-    auto dict = nb::dict();
+    auto obj = SimpleNamespace();
     for (shr_string_ptr str: field_map.get_slots()) {
         auto key = nb::str(str->c_str());
         if (mode == py::ToPythonMode::RECURSIVE) {
-            dict[key] = py::to_python(field_map.at(str), py::ToPythonMode::RECURSIVE);
+            nb::setattr(obj, key, py::to_python(field_map.at(str), py::ToPythonMode::RECURSIVE));
         } else { // non-recursive convert
-            dict[key] = py::to_python_cast(field_map.at(str));
+            nb::setattr(obj, key, py::to_python_cast(field_map.at(str)));
         }
     }
-    return dict;
+    return obj;
 }
 
 __attribute__((__visibility__("default"))) void

--- a/src/stst_py.cpp
+++ b/src/stst_py.cpp
@@ -14,12 +14,12 @@ namespace nb = nanobind;
 
 nb::object py::SimpleNamespace;
 
-std::unordered_map<uint64_t, const py::PyType>& py::get_py_types() {
-    static auto* from_python_fns = new std::unordered_map<uint64_t, const py::PyType>();
+std::unordered_map<type_hash_t, const py::PyType>& py::get_py_types() {
+    static auto* from_python_fns = new std::unordered_map<type_hash_t, const py::PyType>();
     return *from_python_fns;
 }
 
-const py::PyType& py::get_py_type(uint64_t type_hash) {
+const py::PyType& py::get_py_type(type_hash_t type_hash) {
     try {
         return py::get_py_types().at(type_hash);
     } catch (const std::out_of_range&) {

--- a/src/stst_py.cpp
+++ b/src/stst_py.cpp
@@ -41,6 +41,20 @@ py::field_map_to_python(const FieldMapBase& field_map, py::ToPythonMode mode) {
     return dict;
 }
 
+__attribute__((__visibility__("default"))) void
+py::field_map_from_python(FieldMap<false>& field_map, const nb::dict& dict,
+                          const FieldTypeBase& parent_field) {
+    STST_LOG_DEBUG() << "copying __dict__ to " << &field_map;
+    if (field_map.get_slots().size() != dict.size()) {
+        Callstack::throw_with_trace<std::runtime_error>(
+                "cannot copy dict with wrong fields into struct");
+    }
+    for (const shr_string* str: field_map.get_slots()) {
+        std::string key_str = str->c_str();
+        py::set_field(field_map, key_str, dict[str->c_str()], parent_field);
+    }
+}
+
 __attribute__((__visibility__("default"))) nb::object py::to_python(const Field& field,
                                                                     ToPythonMode mode) {
     if (field.empty()) {

--- a/src/stst_shared.cpp
+++ b/src/stst_shared.cpp
@@ -3,29 +3,19 @@
 #include "structstore/stst_callstack.hpp"
 #include "structstore/stst_structstore.hpp"
 
+// todo: provide a .to_local() method to get a StructStore copy using static_alloc
+
 using namespace structstore;
 
-std::random_device structstore::rnd_dev;
-
 StructStoreShared::SharedData::SharedData(size_t size, size_t bufsize, void* buffer)
-    : original_ptr{this}, size{size}, usage_count{1}, sh_alloc{buffer, bufsize},
-      invalidated{false} {
+    : size{size}, usage_count{1}, sh_alloc{buffer, bufsize}, invalidated{false} {
     store = StlAllocator<StructStore>(sh_alloc).allocate(1);
-    new (store) StructStore(sh_alloc);
+    new (store.get()) StructStore(sh_alloc);
 }
 
-StructStoreShared::StructStoreShared(
-        const std::string& path,
-        size_t bufsize,
-        bool reinit,
-        bool use_file,
-        CleanupMode cleanup,
-        void* target_addr)
-        : path(path),
-          fd{-1},
-          sh_data_ptr{nullptr},
-          use_file{use_file},
-          cleanup{cleanup} {
+StructStoreShared::StructStoreShared(const std::string& path, size_t bufsize, bool reinit,
+                                     bool use_file, CleanupMode cleanup)
+    : path(path), fd{-1}, sh_data_ptr{nullptr}, use_file{use_file}, cleanup{cleanup} {
 
     if (use_file) {
         fd = FD(open(path.c_str(), O_EXCL | O_CREAT | O_RDWR, 0600));
@@ -101,31 +91,10 @@ StructStoreShared::StructStoreShared(
 
         // share memory
 
-        if (target_addr == nullptr) {
-            // choose a random address in 48 bit space to avoid collisions
-            std::mt19937 rng(rnd_dev());
-            std::uniform_int_distribution<std::mt19937::result_type> dist(1, 1 << 30);
-            target_addr = (void*) (((uint64_t) dist(rng)) << (47 - 30));
-        }
-        auto map_flags = MAP_SHARED | MAP_FIXED_NOREPLACE;
-        #ifdef __SANITIZE_ADDRESS__
-        target_addr = nullptr;
-        map_flags = MAP_SHARED;
-        #endif
-        sh_data_ptr = (SharedData*) mmap(
-                target_addr,
-                size,
-                PROT_READ | PROT_WRITE,
-                map_flags,
-                fd.get(),
-                0);
+        sh_data_ptr =
+                (SharedData*) mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd.get(), 0);
 
-        if (sh_data_ptr == MAP_FAILED) {
-            throw std::runtime_error("mmap'ing new memory failed");
-        }
-        if (target_addr != nullptr && sh_data_ptr != target_addr) {
-            throw std::runtime_error("mmap'ing new memory to requested address failed");
-        }
+        if (sh_data_ptr == MAP_FAILED) { throw std::runtime_error("mmap'ing new memory failed"); }
 
         // initialize data
 
@@ -161,30 +130,10 @@ StructStoreShared::StructStoreShared(int fd, bool init)
     size_t bufsize = size - sizeof(SharedData);
 
     if (init) {
-        // choose a random address in 48 bit space to avoid collisions
-        std::mt19937 rng(rnd_dev());
-        std::uniform_int_distribution<std::mt19937::result_type> dist(1, 1 << 30);
-        void* target_addr = (void*) (((uint64_t) dist(rng)) << (47 - 30));
         // map new memory
-        auto map_flags = MAP_SHARED | MAP_FIXED_NOREPLACE;
-        #ifdef __SANITIZE_ADDRESS__
-        target_addr = nullptr;
-        map_flags = MAP_SHARED;
-        #endif
-        sh_data_ptr = (SharedData*) mmap(
-                target_addr,
-                size,
-                PROT_READ | PROT_WRITE,
-                map_flags,
-                fd,
-                0);
+        sh_data_ptr = (SharedData*) mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 
-        if (sh_data_ptr == MAP_FAILED) {
-            throw std::runtime_error("mmap'ing new memory failed");
-        }
-        if (sh_data_ptr != target_addr) {
-            throw std::runtime_error("mmap'ing new memory to requested address failed");
-        }
+        if (sh_data_ptr == MAP_FAILED) { throw std::runtime_error("mmap'ing new memory failed"); }
 
         // initialize data
         static_assert((sizeof(SharedData) % 8) == 0);
@@ -200,15 +149,8 @@ StructStoreShared::StructStoreShared(int fd, bool init)
 
 void StructStoreShared::mmap_existing_fd() {
 
-    SharedData* original_ptr;
-
-    ssize_t result = read(fd.get(), &original_ptr, sizeof(SharedData*));
-    if (result != sizeof(SharedData*)) {
-        throw std::runtime_error("reading original pointer failed");
-    }
-
     size_t size;
-    result = read(fd.get(), &size, sizeof(size_t));
+    ssize_t result = read(fd.get(), &size, sizeof(size_t));
 
     if (result != sizeof(size_t)) {
         throw std::runtime_error("reading original size failed");
@@ -219,24 +161,10 @@ void StructStoreShared::mmap_existing_fd() {
     }
 
     lseek(fd.get(), 0, SEEK_SET);
-    sh_data_ptr = (SharedData*) mmap(
-            original_ptr,
-            size,
-            PROT_READ | PROT_WRITE,
-            // ensures that the shared memory segment is mapped
-            // to the same region of memory for all processes
-            // the memory allocator relies on that
-            MAP_SHARED | MAP_FIXED_NOREPLACE,
-            fd.get(),
-            0);
+    sh_data_ptr =
+            (SharedData*) mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd.get(), 0);
 
-    if (sh_data_ptr == MAP_FAILED || sh_data_ptr != original_ptr) {
-        throw std::runtime_error("mmap'ing existing memory failed");
-    }
-
-    if (sh_data_ptr->original_ptr != original_ptr) {
-        throw std::runtime_error("inconsistency detected");
-    }
+    if (sh_data_ptr == MAP_FAILED) { throw std::runtime_error("mmap'ing existing memory failed"); }
 
     ++sh_data_ptr->usage_count;
 
@@ -308,7 +236,7 @@ void StructStoreShared::close() {
         // if cleanup == ALWAYS this ensure that unlink is done exactly once
         if (sh_data_ptr->invalidated.compare_exchange_strong(expected, true, std::memory_order_acquire)) {
             sh_data_ptr->store->~StructStore();
-            sh_data_ptr->sh_alloc.deallocate(sh_data_ptr->store);
+            sh_data_ptr->sh_alloc.deallocate(sh_data_ptr->store.get());
             sh_data_ptr->sh_alloc.~SharedAlloc();
             if (use_file) {
                 unlink(path.c_str());
@@ -335,9 +263,6 @@ void StructStoreShared::from_buffer(void* buffer, size_t bufsize) {
     if (bufsize < ((SharedData*) buffer)->size) {
         throw std::runtime_error("source buffer too small");
     }
-    if (((SharedData*) buffer)->original_ptr != sh_data_ptr) {
-        throw std::runtime_error("target address mismatch; please reopen with correct target address");
-    }
     std::memcpy(sh_data_ptr, buffer, ((SharedData*) buffer)->size);
 }
 
@@ -349,6 +274,5 @@ bool StructStoreShared::operator==(const StructStoreShared& other) const {
 
 void StructStoreShared::check() const {
     CallstackEntry entry{"structstore::StructStoreShared::check()"};
-    stst_assert(sh_data_ptr->sh_alloc.is_owned(sh_data_ptr->store));
     sh_data_ptr->store->check(&sh_data_ptr->sh_alloc);
 }

--- a/src/stst_shared.cpp
+++ b/src/stst_shared.cpp
@@ -9,7 +9,7 @@ using namespace structstore;
 
 StructStoreShared::SharedData::SharedData(size_t size, size_t bufsize, void* buffer)
     : size{size}, usage_count{1}, sh_alloc{buffer, bufsize}, invalidated{false} {
-    store = StlAllocator<StructStore>(sh_alloc).allocate(1);
+    store = sh_alloc.allocate<StructStore>();
     new (store.get()) StructStore(sh_alloc);
 }
 

--- a/src/stst_structstore.cpp
+++ b/src/stst_structstore.cpp
@@ -6,9 +6,9 @@ using namespace structstore;
 const TypeInfo& StructStore::type_info =
         typing::register_type<StructStore>("structstore::StructStore");
 
-void StructStore::check(const MiniMalloc* mm_alloc) const {
+void StructStore::check(const SharedAlloc* sh_alloc) const {
     CallstackEntry entry{"structstore::StructStore::check()"};
-    field_map.check(mm_alloc, *this);
+    field_map.check(sh_alloc, *this);
 }
 
 FieldAccess<true> StructStore::at(const std::string& name) {

--- a/src/stst_typing.cpp
+++ b/src/stst_typing.cpp
@@ -13,15 +13,23 @@ void FieldTypeBase::read_unlock_() const {
 }
 
 void FieldTypeBase::write_lock_() const {
-    // the read lock here is intentional
-    if (parent_field) { parent_field->read_lock_(); }
+    if (parent_field) { parent_field->read_or_write_lock_(); }
     mutex.write_lock();
 }
 
 void FieldTypeBase::write_unlock_() const {
-    // the read lock here is intentional
     mutex.write_unlock();
-    if (parent_field) { parent_field->read_unlock_(); }
+    if (parent_field) { parent_field->read_or_write_unlock_(); }
+}
+
+void FieldTypeBase::read_or_write_lock_() const {
+    if (parent_field) { parent_field->read_or_write_lock_(); }
+    mutex.read_or_write_lock();
+}
+
+void FieldTypeBase::read_or_write_unlock_() const {
+    mutex.read_or_write_unlock();
+    if (parent_field) { parent_field->read_or_write_unlock_(); }
 }
 
 std::unordered_map<std::type_index, uint64_t>& typing::get_type_hashes() {

--- a/src/stst_typing.cpp
+++ b/src/stst_typing.cpp
@@ -3,13 +3,13 @@
 using namespace structstore;
 
 void FieldTypeBase::read_lock_() const {
-    if (parent_field) { parent_field->read_lock_(); }
+    if (parent_field) { parent_field->read_or_write_lock_(); }
     mutex.read_lock();
 }
 
 void FieldTypeBase::read_unlock_() const {
     mutex.read_unlock();
-    if (parent_field) { parent_field->read_unlock_(); }
+    if (parent_field) { parent_field->read_or_write_unlock_(); }
 }
 
 void FieldTypeBase::write_lock_() const {

--- a/src/stst_typing.cpp
+++ b/src/stst_typing.cpp
@@ -32,17 +32,17 @@ void FieldTypeBase::read_or_write_unlock_() const {
     if (parent_field) { parent_field->read_or_write_unlock_(); }
 }
 
-std::unordered_map<std::type_index, uint64_t>& typing::get_type_hashes() {
-    static auto* types = new std::unordered_map<std::type_index, uint64_t>();
+std::unordered_map<std::type_index, type_hash_t>& typing::get_type_hashes() {
+    static auto* types = new std::unordered_map<std::type_index, type_hash_t>();
     return *types;
 }
 
-std::unordered_map<uint64_t, const TypeInfo>& typing::get_type_infos() {
-    static auto* type_infos = new std::unordered_map<uint64_t, const TypeInfo>();
+std::unordered_map<type_hash_t, const TypeInfo>& typing::get_type_infos() {
+    static auto* type_infos = new std::unordered_map<type_hash_t, const TypeInfo>();
     return *type_infos;
 }
 
-const TypeInfo& typing::get_type(uint64_t type_hash) {
+const TypeInfo& typing::get_type(type_hash_t type_hash) {
     try {
         return get_type_infos().at(type_hash);
     } catch (const std::out_of_range&) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,33 +6,36 @@ project(structstore_tests)
 option(BUILD_WITH_PYTHON
     "Build StructStore tests with Python bindings" OFF)
 
+# paths
+
+set(STRUCTSTORE_TESTS_DIR ${PROJECT_SOURCE_DIR})
+
 # dependencies
+
+include(FetchContent)
 
 if(${BUILD_WITH_PYTHON})
     message(STATUS "Building with Python bindings")
-    find_package(Python 3.9 COMPONENTS Interpreter Development REQUIRED)
-
-    execute_process(
-            COMMAND "${Python_EXECUTABLE}" -c "import nanobind; print(nanobind.cmake_dir())"
-            OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE NB_DIR)
-    list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
-    find_package(nanobind CONFIG REQUIRED)
-    include(${PROJECT_SOURCE_DIR}/../cmake/NanobindStubgen.cmake)
+    find_package(Python 3.10 COMPONENTS Interpreter Development REQUIRED)
 
     execute_process(
             COMMAND "${Python_EXECUTABLE}" -c "import structstore; print(structstore.cmake_dir())"
-            OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE STRUCTSTORE_DIR)
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            OUTPUT_VARIABLE STRUCTSTORE_DIR
+            RESULT_VARIABLE STATUS)
+    if(STATUS AND NOT STATUS EQUAL 0)
+        message(FATAL_ERROR "getting structstore path failed with exit code ${STATUS}")
+    endif()
     list(APPEND CMAKE_PREFIX_PATH "${STRUCTSTORE_DIR}")
-
-    include(${PROJECT_SOURCE_DIR}/../cmake/StructStoreBindings.cmake)
 endif()
 
 find_package(StructStore REQUIRED)
 if(${BUILD_WITH_PYTHON})
     find_package(StructStorePy REQUIRED)
+
+    include(${STRUCTSTORE_CMAKE_DIR}/StructStoreBindings.cmake)
 endif()
 
 # define tests
 
-set(STRUCTSTORE_TESTS_DIR ${PROJECT_SOURCE_DIR})
 include(${PROJECT_SOURCE_DIR}/DefineTests.cmake)

--- a/tests/DefineTests.cmake
+++ b/tests/DefineTests.cmake
@@ -12,6 +12,7 @@ endforeach()
 
 set(TEST_TARGETS "")
 list(APPEND TEST_TARGETS test_alloc)
+list(APPEND TEST_TARGETS test_offsetptr)
 list(APPEND TEST_TARGETS test_basic_0)
 list(APPEND TEST_TARGETS test_basic_1)
 list(APPEND TEST_TARGETS test_mystruct0)

--- a/tests/DefineTests.cmake
+++ b/tests/DefineTests.cmake
@@ -11,10 +11,12 @@ foreach(TEST_LIB_TARGET ${TEST_LIB_TARGETS})
 endforeach()
 
 set(TEST_TARGETS "")
+list(APPEND TEST_TARGETS test_alloc)
 list(APPEND TEST_TARGETS test_basic_0)
 list(APPEND TEST_TARGETS test_basic_1)
 list(APPEND TEST_TARGETS test_mystruct0)
 list(APPEND TEST_TARGETS test_mystruct1)
+list(APPEND TEST_TARGETS test_utils)
 
 foreach(TEST_TARGET ${TEST_TARGETS})
     add_executable(${TEST_TARGET} ${STRUCTSTORE_TESTS_DIR}/${TEST_TARGET}.cpp)
@@ -28,15 +30,22 @@ if(${BUILD_WITH_PYTHON})
 endif()
 
 foreach(TEST_TARGET ${TEST_TARGETS})
-    target_compile_features(${TEST_TARGET} PUBLIC cxx_std_17)
-    target_compile_options(${TEST_TARGET} PUBLIC -Wall -Wextra -pedantic -Werror)
-    target_include_directories(${TEST_TARGET} PRIVATE ${STRUCTSTORE_INCLUDE_DIR})
     target_link_libraries(${TEST_TARGET} PRIVATE
         structstore_lib
         ${GTEST_BOTH_LIBRARIES}
         ${TEST_LIB_TARGETS})
+endforeach()
+
+foreach(TEST_TARGET ${TEST_TARGETS} ${TEST_LIB_TARGETS})
+    target_compile_features(${TEST_TARGET} PUBLIC cxx_std_17)
+    target_compile_options(${TEST_TARGET} PUBLIC -Wall -Wextra -pedantic -Werror)
+    target_include_directories(${TEST_TARGET} PRIVATE ${STRUCTSTORE_INCLUDE_DIR})
     if(${BUILD_WITH_SANITIZER})
         target_compile_options(${TEST_TARGET} PRIVATE -fsanitize=address)
         target_link_libraries(${TEST_TARGET} PRIVATE -fsanitize=address)
+    endif()
+    if(${BUILD_WITH_COVERAGE})
+        target_compile_options(${TEST_TARGET} PRIVATE --coverage -fprofile-arcs -ftest-coverage -g -O0 -fno-lto)
+        target_link_libraries(${TEST_TARGET} PRIVATE  gcov -fprofile-arcs -ftest-coverage -fno-lto)
     endif()
 endforeach()

--- a/tests/mystruct0.hpp
+++ b/tests/mystruct0.hpp
@@ -12,15 +12,11 @@ struct Frame : public stst::Struct<Frame> {
     bool flag = false;
     stst::OffsetPtr<double> t_ptr = &t;
 
-    Frame() : Frame(stst::static_alloc) {}
-
     explicit Frame(stst::SharedAlloc& sh_alloc) : Struct(sh_alloc) {
         store_ref("t", t);
         store_ref("flag", flag);
         store_ref("t_ptr", t_ptr);
     }
-
-    Frame(const Frame& other) : Frame() { *this = other; }
 
     Frame& operator=(const Frame& other) {
         copy_from(other);

--- a/tests/mystruct0.hpp
+++ b/tests/mystruct0.hpp
@@ -10,7 +10,7 @@ struct Frame : public stst::Struct<Frame> {
 
     double t = 0.0;
     bool flag = false;
-    double* t_ptr = &t;
+    stst::OffsetPtr<double> t_ptr = &t;
 
     Frame() : Frame(stst::static_alloc) {}
 

--- a/tests/mystruct0.hpp
+++ b/tests/mystruct0.hpp
@@ -14,7 +14,7 @@ struct Frame : public stst::Struct<Frame> {
 
     Frame() : Frame(stst::static_alloc) {}
 
-    explicit Frame(stst::MiniMalloc& mm_alloc) : Struct(mm_alloc) {
+    explicit Frame(stst::SharedAlloc& sh_alloc) : Struct(sh_alloc) {
         store_ref("t", t);
         store_ref("flag", flag);
         store_ref("t_ptr", t_ptr);

--- a/tests/mystruct0_py.cpp
+++ b/tests/mystruct0_py.cpp
@@ -6,9 +6,9 @@
 namespace nb = nanobind;
 
 NB_MODULE(MODULE_NAME, m) {
-    auto frame_cls = nb::class_<Frame>(m, "Frame");
-    stst::py::register_struct_type<Frame>(frame_cls);
+    auto frame_cls = nb::class_<Frame::Ref>(m, "Frame");
+    stst::py::register_struct_type<Frame::Ref>(frame_cls);
 
-    auto track_cls = nb::class_<Track>(m, "Track");
-    stst::py::register_struct_type<Track>(track_cls);
+    auto track_cls = nb::class_<Track::Ref>(m, "Track");
+    stst::py::register_struct_type<Track::Ref>(track_cls);
 }

--- a/tests/mystruct0_py.cpp
+++ b/tests/mystruct0_py.cpp
@@ -7,10 +7,8 @@ namespace nb = nanobind;
 
 NB_MODULE(MODULE_NAME, m) {
     auto frame_cls = nb::class_<Frame>(m, "Frame");
-    frame_cls.def(nb::init());
     stst::py::register_struct_type<Frame>(frame_cls);
 
     auto track_cls = nb::class_<Track>(m, "Track");
-    track_cls.def(nb::init());
     stst::py::register_struct_type<Track>(track_cls);
 }

--- a/tests/mystruct1.hpp
+++ b/tests/mystruct1.hpp
@@ -13,16 +13,12 @@ struct Track : public stst::Struct<Track> {
     Frame frame2;
     stst::OffsetPtr<Frame> frame_ptr = &frame1;
 
-    Track() : Track(stst::static_alloc) {}
-
     explicit Track(stst::SharedAlloc& sh_alloc)
         : Struct(sh_alloc), frame1{sh_alloc}, frame2{sh_alloc} {
         store_ref("frame1", frame1);
         store_ref("frame2", frame2);
         store_ref("frame_ptr", frame_ptr);
     }
-
-    Track(const Track& other) : Track() { *this = other; }
 
     Track& operator=(const Track& other) {
         copy_from(other);

--- a/tests/mystruct1.hpp
+++ b/tests/mystruct1.hpp
@@ -11,7 +11,7 @@ struct Track : public stst::Struct<Track> {
 
     Frame frame1;
     Frame frame2;
-    Frame* frame_ptr = &frame1;
+    stst::OffsetPtr<Frame> frame_ptr = &frame1;
 
     Track() : Track(stst::static_alloc) {}
 

--- a/tests/mystruct1.hpp
+++ b/tests/mystruct1.hpp
@@ -15,8 +15,8 @@ struct Track : public stst::Struct<Track> {
 
     Track() : Track(stst::static_alloc) {}
 
-    explicit Track(stst::MiniMalloc& mm_alloc)
-        : Struct(mm_alloc), frame1{mm_alloc}, frame2{mm_alloc} {
+    explicit Track(stst::SharedAlloc& sh_alloc)
+        : Struct(sh_alloc), frame1{sh_alloc}, frame2{sh_alloc} {
         store_ref("frame1", frame1);
         store_ref("frame2", frame2);
         store_ref("frame_ptr", frame_ptr);

--- a/tests/test_alloc.cpp
+++ b/tests/test_alloc.cpp
@@ -9,7 +9,7 @@ TEST(StructStoreTestAlloc, bigAlloc) {
     EXPECT_THROW(
             try { stst::static_alloc.allocate(10'000'000); } catch (const std::runtime_error& e) {
                 EXPECT_STREQ(e.what(),
-                             "prefix: insufficient space in mm_alloc region, requested: 10000000");
+                             "prefix: insufficient space in sh_alloc region, requested: 10000000");
                 throw;
             },
             std::runtime_error);

--- a/tests/test_alloc.cpp
+++ b/tests/test_alloc.cpp
@@ -4,6 +4,14 @@
 
 namespace stst = structstore;
 
+TEST(StructStoreTestAlloc, structSizes) {
+    EXPECT_EQ(sizeof(stst::FieldTypeBase), 16);
+    EXPECT_EQ(sizeof(stst::Field), 16);
+    EXPECT_EQ(sizeof(stst::String), 56);
+    EXPECT_EQ(sizeof(stst::StructStore), 128);
+    EXPECT_EQ(sizeof(stst::SharedAlloc), 32);
+}
+
 TEST(StructStoreTestAlloc, bigAlloc) {
     stst::CallstackEntry entry{"prefix"};
     EXPECT_THROW(

--- a/tests/test_alloc.cpp
+++ b/tests/test_alloc.cpp
@@ -8,16 +8,20 @@ TEST(StructStoreTestAlloc, structSizes) {
     EXPECT_EQ(sizeof(stst::FieldTypeBase), 16);
     EXPECT_EQ(sizeof(stst::Field), 16);
     EXPECT_EQ(sizeof(stst::String), 56);
-    EXPECT_EQ(sizeof(stst::StructStore), 128);
-    EXPECT_EQ(sizeof(stst::SharedAlloc), 32);
+    EXPECT_EQ(sizeof(stst::StructStore), 136);
+    EXPECT_EQ(sizeof(stst::SharedAlloc), 64);
 }
 
 TEST(StructStoreTestAlloc, bigAlloc) {
     stst::CallstackEntry entry{"prefix"};
+#ifndef NDEBUG
+#define EXPECTED_STR "prefix: insufficient space in sh_alloc region, requested: 10000000"
+#else
+#define EXPECTED_STR "insufficient space in sh_alloc region, requested: 10000000"
+#endif
     EXPECT_THROW(
             try { stst::static_alloc.allocate(10'000'000); } catch (const std::runtime_error& e) {
-                EXPECT_STREQ(e.what(),
-                             "prefix: insufficient space in sh_alloc region, requested: 10000000");
+                EXPECT_STREQ(e.what(), EXPECTED_STR);
                 throw;
             },
             std::runtime_error);

--- a/tests/test_alloc.cpp
+++ b/tests/test_alloc.cpp
@@ -5,11 +5,12 @@
 namespace stst = structstore;
 
 TEST(StructStoreTestAlloc, structSizes) {
-    EXPECT_EQ(sizeof(stst::FieldTypeBase), 16);
-    EXPECT_EQ(sizeof(stst::Field), 16);
+    EXPECT_EQ(sizeof(stst::SpinMutex), 8);
+    EXPECT_EQ(sizeof(stst::FieldTypeBase), 12);
+    EXPECT_EQ(sizeof(stst::Field), 8);
     EXPECT_EQ(sizeof(stst::String), 56);
     EXPECT_EQ(sizeof(stst::StructStore), 136);
-    EXPECT_EQ(sizeof(stst::SharedAlloc), 64);
+    EXPECT_EQ(sizeof(stst::SharedAlloc), 20);
 }
 
 TEST(StructStoreTestAlloc, bigAlloc) {

--- a/tests/test_alloc.cpp
+++ b/tests/test_alloc.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+
+#include <structstore/structstore.hpp>
+
+namespace stst = structstore;
+
+TEST(StructStoreTestAlloc, bigAlloc) {
+    stst::CallstackEntry entry{"prefix"};
+    EXPECT_THROW(
+            try { stst::static_alloc.allocate(10'000'000); } catch (const std::runtime_error& e) {
+                EXPECT_STREQ(e.what(),
+                             "prefix: insufficient space in mm_alloc region, requested: 10000000");
+                throw;
+            },
+            std::runtime_error);
+}
+
+TEST(StructStoreTestAlloc, isOwned) {
+    EXPECT_FALSE(stst::static_alloc.is_owned(nullptr));
+    EXPECT_FALSE(stst::static_alloc.is_owned(&stst::static_alloc));
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_basic_0.cpp
+++ b/tests/test_basic_0.cpp
@@ -26,7 +26,8 @@ struct Settings {
 };
 
 TEST(StructStoreTestBasic, refStructInLocalStore) {
-    stst::StructStore store(stst::static_alloc);
+    auto store_ptr = stst::create<stst::StructStore>();
+    stst::StructStore& store = *store_ptr;
     store["num"] = 5;
     std::ostringstream str;
     str << store;
@@ -45,7 +46,8 @@ TEST(StructStoreTestBasic, refStructInLocalStore) {
         ++i;
     }
     EXPECT_EQ(list.size(), 2);
-    list.push_back(stst::StructStore(stst::static_alloc));
+    auto store_ptr2 = stst::create<stst::StructStore>();
+    list.push_back(*store_ptr2);
     list.check();
     EXPECT_EQ(list.size(), 3);
     for (stst::Field& field: list) {
@@ -89,9 +91,11 @@ TEST(StructStoreTestBasic, sharedStore) {
 }
 
 TEST(StructStoreTestBasic, cmpEqual) {
-    stst::StructStore store1(stst::static_alloc);
+    auto store_ptr1 = stst::create<stst::StructStore>();
+    stst::StructStore& store1 = *store_ptr1;
     Settings settings1{store1};
-    stst::StructStore store2(stst::static_alloc);
+    auto store_ptr2 = stst::create<stst::StructStore>();
+    stst::StructStore& store2 = *store_ptr2;
     Settings settings2{store2};
     EXPECT_EQ(store1, store2);
     settings2.subsettings.substr += '.';
@@ -115,11 +119,14 @@ TEST(StructStoreTestBasic, cmpEqualShared) {
 }
 
 TEST(StructStoreTestBasic, copyStore) {
-    stst::StructStore store(stst::static_alloc);
+    auto store_ptr = stst::create<stst::StructStore>();
+    stst::StructStore& store = *store_ptr;
     int& num = store["num"];
     num = 5;
     store["str"].get_str() = "foo";
-    stst::StructStore store2 = store;
+    auto store_ptr2 = stst::create<stst::StructStore>();
+    stst::StructStore& store2 = *store_ptr2;
+    store2 = store;
     EXPECT_EQ(store2["num"].get<int>(), 5);
     store.check();
     store2.check();

--- a/tests/test_basic_0.cpp
+++ b/tests/test_basic_0.cpp
@@ -26,8 +26,8 @@ struct Settings {
 };
 
 TEST(StructStoreTestBasic, refStructInLocalStore) {
-    auto store_ptr = stst::create<stst::StructStore>();
-    stst::StructStore& store = *store_ptr;
+    auto store_ref = stst::StructStore::create();
+    stst::StructStore& store = *store_ref;
     store["num"] = 5;
     std::ostringstream str;
     str << store;
@@ -40,14 +40,15 @@ TEST(StructStoreTestBasic, refStructInLocalStore) {
     settings.subsettings.subnum = 43;
 
     stst::List& list = store["list"];
-    list.push_back(5);
+    list.push_back(4);
+    store["list"][0] = 5;
     list.push_back(42);
     for (int& i: list) {
         ++i;
     }
     EXPECT_EQ(list.size(), 2);
-    auto store_ptr2 = stst::create<stst::StructStore>();
-    list.push_back(*store_ptr2);
+    auto store_ref2 = stst::StructStore::create();
+    list.push_back(*store_ref2);
     list.check();
     EXPECT_EQ(list.size(), 3);
     for (stst::Field& field: list) {
@@ -91,11 +92,11 @@ TEST(StructStoreTestBasic, sharedStore) {
 }
 
 TEST(StructStoreTestBasic, cmpEqual) {
-    auto store_ptr1 = stst::create<stst::StructStore>();
-    stst::StructStore& store1 = *store_ptr1;
+    auto store_ref1 = stst::StructStore::create();
+    stst::StructStore& store1 = *store_ref1;
     Settings settings1{store1};
-    auto store_ptr2 = stst::create<stst::StructStore>();
-    stst::StructStore& store2 = *store_ptr2;
+    auto store_ref2 = stst::StructStore::create();
+    stst::StructStore& store2 = *store_ref2;
     Settings settings2{store2};
     EXPECT_EQ(store1, store2);
     settings2.subsettings.substr += '.';
@@ -119,13 +120,13 @@ TEST(StructStoreTestBasic, cmpEqualShared) {
 }
 
 TEST(StructStoreTestBasic, copyStore) {
-    auto store_ptr = stst::create<stst::StructStore>();
-    stst::StructStore& store = *store_ptr;
+    auto store_ref = stst::StructStore::create();
+    stst::StructStore& store = *store_ref;
     int& num = store["num"];
     num = 5;
     store["str"].get_str() = "foo";
-    auto store_ptr2 = stst::create<stst::StructStore>();
-    stst::StructStore& store2 = *store_ptr2;
+    auto store_ref2 = stst::StructStore::create();
+    stst::StructStore& store2 = *store_ref2;
     store2 = store;
     EXPECT_EQ(store2["num"].get<int>(), 5);
     store.check();

--- a/tests/test_basic_0.py
+++ b/tests/test_basic_0.py
@@ -1,5 +1,6 @@
 import unittest
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import List, Dict
 
 import numpy as np
@@ -47,11 +48,11 @@ class TestBasic0(unittest.TestCase):
         state2.state = state.deepcopy()
         state2.check()
 
-        # check dict types
+        # check converted types
         self.assertEqual(type(state.sub), structstore.StructStore)
-        self.assertEqual(type(state.copy()), dict)
-        self.assertEqual(type(state.copy()["sub"]), structstore.StructStore)
-        self.assertEqual(type(state.deepcopy()["sub"]), dict)
+        self.assertEqual(type(state.copy()), SimpleNamespace)
+        self.assertEqual(type(state.copy().sub), structstore.StructStore)
+        self.assertEqual(type(state.deepcopy().sub), SimpleNamespace)
 
         # check matrix types
         self.assertEqual(type(state.mat), structstore.StructStoreMatrix)
@@ -60,22 +61,28 @@ class TestBasic0(unittest.TestCase):
         self.assertEqual(state.mat2, state.mat)
 
         state_copy: Dict = state.deepcopy()
-        print(state_copy["vec"])
+        print(state_copy.vec)
         print(state.vec.copy())
-        self.assertTrue((state.vec.copy() == state_copy["vec"]).all())
-        self.assertTrue(state.sub.vec.copy()[0] == state_copy["sub"]["vec"][0])
-        self.assertTrue((state.mat.copy() == state_copy["mat"]).all().all())
-        del state_copy["vec"]
-        del state_copy["sub"]
-        del state_copy["mat"]
-        del state_copy["mat2"]
-        self.assertEqual(state_copy, {
-            "num": 5,
-            "value": 3.14,
-            "mystr": "foo",
-            "lst": [1, 2, 3, 5, 8],
-            "tuple": [0, 0],
-        })
+        self.assertTrue((state.vec.copy() == state_copy.vec).all())
+        self.assertTrue(state.sub.vec.copy()[0] == state_copy.sub.vec[0])
+        self.assertTrue((state.mat.copy() == state_copy.mat).all().all())
+        del state_copy.vec
+        del state_copy.sub
+        del state_copy.mat
+        del state_copy.mat2
+        self.assertEqual(
+            state_copy,
+            SimpleNamespace(
+                **{
+                    "num": 5,
+                    "value": 3.14,
+                    "mystr": "foo",
+                    "lst": [1, 2, 3, 5, 8],
+                    "tuple": [0, 0],
+                }
+            ),
+        )
+        # return
         state.lst.append(42)
         state.lst.insert(0, 42)
         self.assertEqual(len(state.lst), 7)
@@ -89,7 +96,7 @@ class TestBasic0(unittest.TestCase):
         self.assertEqual(type(state.lst2), structstore.StructStoreList)
         self.assertEqual(type(state.lst2.copy()), list)
         self.assertEqual(type(state.lst2.copy()[0]), structstore.StructStore)
-        self.assertEqual(type(state.lst2.deepcopy()[0]), dict)
+        self.assertEqual(type(state.lst2.deepcopy()[0]), SimpleNamespace)
         state.lst2.clear()
         self.assertEqual(state.lst2.copy(), [])
         state.lst3 = state.lst2.copy()

--- a/tests/test_basic_0.py
+++ b/tests/test_basic_0.py
@@ -43,6 +43,10 @@ class TestBasic0(unittest.TestCase):
         del state.flag
         self.assertFalse(hasattr(state, 'flag'))
 
+        state2 = structstore.StructStore()
+        state2.state = state.deepcopy()
+        state2.check()
+
         # check dict types
         self.assertEqual(type(state.sub), structstore.StructStore)
         self.assertEqual(type(state.copy()), dict)

--- a/tests/test_basic_1.cpp
+++ b/tests/test_basic_1.cpp
@@ -46,7 +46,8 @@ void from_store(stst::StructStore& store, Settings& settings) {
 TEST(StructStoreTestBasic, structInStaticStore) {
     Settings settings;
 
-    stst::StructStore store(stst::static_alloc);
+    auto store_ptr = stst::create<stst::StructStore>();
+    stst::StructStore& store = *store_ptr;
     to_store(store, settings);
     std::ostringstream str;
     str << store;

--- a/tests/test_basic_1.cpp
+++ b/tests/test_basic_1.cpp
@@ -46,8 +46,8 @@ void from_store(stst::StructStore& store, Settings& settings) {
 TEST(StructStoreTestBasic, structInStaticStore) {
     Settings settings;
 
-    auto store_ptr = stst::create<stst::StructStore>();
-    stst::StructStore& store = *store_ptr;
+    auto store_ref = stst::StructStore::create();
+    stst::StructStore& store = *store_ref;
     to_store(store, settings);
     std::ostringstream str;
     str << store;

--- a/tests/test_bytes_0.py
+++ b/tests/test_bytes_0.py
@@ -28,12 +28,10 @@ class TestBytes0(unittest.TestCase):
         print(shmem.deepcopy())
         shmem.check()
         buf = shmem.to_bytes()
-        addr = shmem.addr()
         del shmem
 
         shmem = structstore.StructStoreShared(
-            "/dyn_shdata_store2", 4096, reinit=True, cleanup=structstore.CleanupMode.ALWAYS,
-            target_addr=addr)
+            "/dyn_shdata_store2", 4096, reinit=True, cleanup=structstore.CleanupMode.ALWAYS)
         shmem.from_bytes(buf)
         print(shmem.deepcopy())
         shmem.check()

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,0 +1,41 @@
+import unittest
+
+import numpy as np
+
+import structstore
+
+
+class TestContainers(unittest.TestCase):
+    def test_list(self):
+        store = structstore.StructStore()
+        lst = structstore.StructStoreList()
+        store.lst = lst
+        # this is allowed, but a no-op
+        store.lst = store.lst
+
+        lst.append(42)
+
+        def copy_nonempty_list():
+            try:
+                store.lst = lst
+            except RuntimeError as e:
+                self.assertEqual(
+                    str(e), "copy assignment of structstore::List is not supported"
+                )
+                raise
+
+        self.assertRaises(RuntimeError, copy_nonempty_list)
+
+        # out-of-bounds access
+        self.assertRaises(IndexError, lambda: lst[42])
+        self.assertRaises(IndexError, lambda: lst.insert(42, 'foo'))
+        self.assertRaises(IndexError, lambda: lst.pop(42))
+
+    def test_matrix(self):
+        store = structstore.StructStore()
+        store.mat = np.array([1.0, 2.0])
+
+        shmem = structstore.StructStoreShared("/dyn_shdata_store", 16384)
+        shmem.mat = store.mat
+        shmem.mat = store.mat
+        shmem.check()

--- a/tests/test_lock_0.py
+++ b/tests/test_lock_0.py
@@ -17,7 +17,9 @@ class TestLock0(unittest.TestCase):
     def test_lock_1(self):
         state = stst.StructStore()
         state.lst2 = []
+        # one thread can get one write lock (explicitly) ...
         with state.lst2.write_lock():
+            # ... and a second one (implicitly during append) at the same time
             state.lst2.append(stst.StructStore())
 
         # this does not create a read lock anymore
@@ -28,10 +30,53 @@ class TestLock0(unittest.TestCase):
 
         del obj
 
+        # double iter is ok
+        for subs in state.lst2:
+            for subs2 in state.lst2:
+                print(subs2)
+
+    def test_lock_2(self):
+        state = stst.StructStore()
+        state.lst2 = [stst.StructStore()]
+
         with state.lst2.write_lock():
             # cannot use write lock and read lock at the same time
             self.assertRaises(RuntimeError, lambda: state.lst2.read_lock())
 
+        with state.lst2.read_lock():
+            # cannot use write lock and read lock at the same time
+            self.assertRaises(RuntimeError, lambda: state.lst2.write_lock())
+
         for subs in state.lst2:
             # iterating implicitly gets a read lock, so write lock is an error here
             self.assertRaises(RuntimeError, lambda: state.lst2.write_lock())
+
+        def append_while_iter():
+            try:
+                for subs in state.lst2:
+                    # iterating implicitly gets a read lock, so append is an error here
+                    state.lst2.append(5)
+            except RuntimeError as e:
+                # additionally check error message
+                self.assertEqual(str(e), "timeout while getting write lock")
+                raise
+
+        self.assertRaises(RuntimeError, append_while_iter)
+
+        def pop_while_iter():
+            for subs in state.lst2:
+                # iterating implicitly gets a read lock, so pop is an error here
+                state.lst2.pop(0)
+
+        self.assertRaises(RuntimeError, pop_while_iter)
+
+        def extend_by_self():
+            try:
+                state.lst2.extend(state.lst2)
+            except RuntimeError as e:
+                # additionally check error message
+                self.assertEqual(str(e), "trying to acquire read lock while current thread has write lock")
+                raise
+
+        # extending by itself would need a read lock and a write lock
+        self.assertRaises(RuntimeError, extend_by_self)

--- a/tests/test_mystruct0.cpp
+++ b/tests/test_mystruct0.cpp
@@ -6,16 +6,16 @@
 namespace stst = structstore;
 
 TEST(StructStoreTestStruct, structCreation) {
-    auto store_ptr = stst::create<stst::StructStore>();
-    stst::StructStore& store = *store_ptr;
+    auto store_ref = stst::StructStore::create();
+    stst::StructStore& store = *store_ref;
     store.get<Frame>("frame");
     store.check();
 
     std::string yaml_str = (std::ostringstream() << store.to_yaml()).str();
     EXPECT_EQ(yaml_str, "frame:\n  t: 0\n  flag: false\n  t_ptr: <double_ptr>");
 
-    auto store_ptr2 = stst::create<stst::StructStore>();
-    stst::StructStore& store2 = *store_ptr2;
+    auto store_ref2 = stst::StructStore::create();
+    stst::StructStore& store2 = *store_ref2;
     store2 = store;
     EXPECT_EQ(store, store2);
     store2["frame"].get<Frame>().t = 1.0;
@@ -24,12 +24,12 @@ TEST(StructStoreTestStruct, structCreation) {
 }
 
 TEST(StructStoreTestStruct, structBasicFuncs) {
-    auto f_ptr = stst::create<Frame>();
-    Frame& f = *f_ptr;
+    auto f_ref = Frame::create();
+    Frame& f = *f_ref;
     f.flag = true;
     f.t = 2.5;
-    auto f2_ptr = stst::create<Frame>();
-    Frame& f2 = *f2_ptr;
+    auto f2_ref = Frame::create();
+    Frame& f2 = *f2_ref;
     f2 = f;
     EXPECT_EQ(f, f2);
 
@@ -45,8 +45,8 @@ TEST(StructStoreTestStruct, sharedStruct) {
     std::string yaml_str = (std::ostringstream() << shdata_store->to_yaml()).str();
     EXPECT_EQ(yaml_str, "frame:\n  t: 0\n  flag: false\n  t_ptr: <double_ptr>");
 
-    auto store_ptr2 = stst::create<stst::StructStore>();
-    stst::StructStore& store2 = *store_ptr2;
+    auto store_ref2 = stst::StructStore::create();
+    stst::StructStore& store2 = *store_ref2;
     store2 = *shdata_store;
     EXPECT_EQ(*shdata_store, store2);
     store2["frame"].get<Frame>().t = 1.0;

--- a/tests/test_mystruct0.cpp
+++ b/tests/test_mystruct0.cpp
@@ -12,7 +12,7 @@ TEST(StructStoreTestStruct, structCreation) {
     store.check();
 
     std::string yaml_str = (std::ostringstream() << store.to_yaml()).str();
-    EXPECT_EQ(yaml_str, "frame:\n  t: 0\n  flag: false\n  t_ptr: <double*>");
+    EXPECT_EQ(yaml_str, "frame:\n  t: 0\n  flag: false\n  t_ptr: <double_ptr>");
 
     stst::StructStore store2 = store;
     EXPECT_EQ(store, store2);
@@ -29,7 +29,7 @@ TEST(StructStoreTestStruct, structBasicFuncs) {
     EXPECT_EQ(f, f2);
 
     std::string str = (std::ostringstream() << f).str();
-    EXPECT_EQ(str, "{\"t\":2.5,\"flag\":1,\"t_ptr\":<double*>,}");
+    EXPECT_EQ(str, "{\"t\":2.5,\"flag\":1,\"t_ptr\":<double_ptr>,}");
 }
 
 TEST(StructStoreTestStruct, sharedStruct) {
@@ -39,7 +39,7 @@ TEST(StructStoreTestStruct, sharedStruct) {
     shdata_store.check();
 
     std::string yaml_str = (std::ostringstream() << shdata_store->to_yaml()).str();
-    EXPECT_EQ(yaml_str, "frame:\n  t: 0\n  flag: false\n  t_ptr: <double*>");
+    EXPECT_EQ(yaml_str, "frame:\n  t: 0\n  flag: false\n  t_ptr: <double_ptr>");
 
     stst::StructStore store2 = *shdata_store;
     EXPECT_EQ(*shdata_store, store2);

--- a/tests/test_mystruct0.cpp
+++ b/tests/test_mystruct0.cpp
@@ -6,15 +6,17 @@
 namespace stst = structstore;
 
 TEST(StructStoreTestStruct, structCreation) {
-    stst::StructStore store(stst::static_alloc);
-    Frame f;
-    store["frame"] = f;
+    auto store_ptr = stst::create<stst::StructStore>();
+    stst::StructStore& store = *store_ptr;
+    store.get<Frame>("frame");
     store.check();
 
     std::string yaml_str = (std::ostringstream() << store.to_yaml()).str();
     EXPECT_EQ(yaml_str, "frame:\n  t: 0\n  flag: false\n  t_ptr: <double_ptr>");
 
-    stst::StructStore store2 = store;
+    auto store_ptr2 = stst::create<stst::StructStore>();
+    stst::StructStore& store2 = *store_ptr2;
+    store2 = store;
     EXPECT_EQ(store, store2);
     store2["frame"].get<Frame>().t = 1.0;
     EXPECT_NE(store, store2);
@@ -22,10 +24,13 @@ TEST(StructStoreTestStruct, structCreation) {
 }
 
 TEST(StructStoreTestStruct, structBasicFuncs) {
-    Frame f;
+    auto f_ptr = stst::create<Frame>();
+    Frame& f = *f_ptr;
     f.flag = true;
     f.t = 2.5;
-    Frame f2 = f;
+    auto f2_ptr = stst::create<Frame>();
+    Frame& f2 = *f2_ptr;
+    f2 = f;
     EXPECT_EQ(f, f2);
 
     std::string str = (std::ostringstream() << f).str();
@@ -34,14 +39,15 @@ TEST(StructStoreTestStruct, structBasicFuncs) {
 
 TEST(StructStoreTestStruct, sharedStruct) {
     stst::StructStoreShared shdata_store("/shdata_store");
-    Frame f;
-    shdata_store["frame"] = f;
+    shdata_store->get<Frame>("frame");
     shdata_store.check();
 
     std::string yaml_str = (std::ostringstream() << shdata_store->to_yaml()).str();
     EXPECT_EQ(yaml_str, "frame:\n  t: 0\n  flag: false\n  t_ptr: <double_ptr>");
 
-    stst::StructStore store2 = *shdata_store;
+    auto store_ptr2 = stst::create<stst::StructStore>();
+    stst::StructStore& store2 = *store_ptr2;
+    store2 = *shdata_store;
     EXPECT_EQ(*shdata_store, store2);
     store2["frame"].get<Frame>().t = 1.0;
     EXPECT_NE(*shdata_store, store2);

--- a/tests/test_mystruct1.cpp
+++ b/tests/test_mystruct1.cpp
@@ -6,8 +6,8 @@
 namespace stst = structstore;
 
 TEST(StructStoreTestStruct, nestedStruct) {
-    auto store_ptr = stst::create<stst::StructStore>();
-    stst::StructStore& store = *store_ptr;
+    auto store_ref = stst::StructStore::create();
+    stst::StructStore& store = *store_ref;
     store.get<Track>("track");
     store.check();
 
@@ -16,8 +16,8 @@ TEST(StructStoreTestStruct, nestedStruct) {
               "track:\n  frame1:\n    t: 0\n    flag: false\n    t_ptr: <double_ptr>\n  frame2:\n    "
               "t: 0\n    flag: false\n    t_ptr: <double_ptr>\n  frame_ptr: <Frame_ptr>");
 
-    auto store_ptr2 = stst::create<stst::StructStore>();
-    stst::StructStore& store2 = *store_ptr2;
+    auto store_ref2 = stst::StructStore::create();
+    stst::StructStore& store2 = *store_ref2;
     store2 = store;
     EXPECT_EQ(store, store2);
     store2["track"].get<Track>().frame1.t = 1.0;

--- a/tests/test_mystruct1.cpp
+++ b/tests/test_mystruct1.cpp
@@ -13,8 +13,8 @@ TEST(StructStoreTestStruct, nestedStruct) {
 
     std::string yaml_str = (std::ostringstream() << store.to_yaml()).str();
     EXPECT_EQ(yaml_str,
-              "track:\n  frame1:\n    t: 0\n    flag: false\n    t_ptr: <double*>\n  frame2:\n    "
-              "t: 0\n    flag: false\n    t_ptr: <double*>\n  frame_ptr: <Frame*>");
+              "track:\n  frame1:\n    t: 0\n    flag: false\n    t_ptr: <double_ptr>\n  frame2:\n    "
+              "t: 0\n    flag: false\n    t_ptr: <double_ptr>\n  frame_ptr: <Frame_ptr>");
 
     stst::StructStore store2 = store;
     EXPECT_EQ(store, store2);

--- a/tests/test_mystruct1.cpp
+++ b/tests/test_mystruct1.cpp
@@ -6,9 +6,9 @@
 namespace stst = structstore;
 
 TEST(StructStoreTestStruct, nestedStruct) {
-    stst::StructStore store(stst::static_alloc);
-    Track track;
-    store["track"] = track;
+    auto store_ptr = stst::create<stst::StructStore>();
+    stst::StructStore& store = *store_ptr;
+    store.get<Track>("track");
     store.check();
 
     std::string yaml_str = (std::ostringstream() << store.to_yaml()).str();
@@ -16,7 +16,9 @@ TEST(StructStoreTestStruct, nestedStruct) {
               "track:\n  frame1:\n    t: 0\n    flag: false\n    t_ptr: <double_ptr>\n  frame2:\n    "
               "t: 0\n    flag: false\n    t_ptr: <double_ptr>\n  frame_ptr: <Frame_ptr>");
 
-    stst::StructStore store2 = store;
+    auto store_ptr2 = stst::create<stst::StructStore>();
+    stst::StructStore& store2 = *store_ptr2;
+    store2 = store;
     EXPECT_EQ(store, store2);
     store2["track"].get<Track>().frame1.t = 1.0;
     EXPECT_NE(store, store2);

--- a/tests/test_mystruct_0.py
+++ b/tests/test_mystruct_0.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 import unittest
 import pickle
 
@@ -11,7 +12,7 @@ class TestMystruct0(unittest.TestCase):
         frame = Frame()
         frame.t = 2.5
         self.assertEqual(frame, frame)
-        self.assertEqual(type(frame.copy()), dict)
+        self.assertEqual(type(frame.copy()), SimpleNamespace)
         state = structstore.StructStore()
         state.frame = frame
         self.assertEqual(state.frame.t, 2.5)
@@ -31,10 +32,10 @@ class TestMystruct0(unittest.TestCase):
         self.assertNotEqual(state.track.frame1, state.track.frame2)
         state.track.frame_ptr = state.frame
         self.assertEqual(type(state.track.frame_ptr), Frame)
-        self.assertEqual(type(state.track.frame_ptr.copy()), dict)
+        self.assertEqual(type(state.track.frame_ptr.copy()), SimpleNamespace)
         self.assertEqual(state.track.frame_ptr, state.frame)
-        frame_ptr = state.track.deepcopy()["frame_ptr"]
-        self.assertEqual(type(frame_ptr), dict)
+        frame_ptr = state.track.deepcopy().frame_ptr
+        self.assertEqual(type(frame_ptr), SimpleNamespace)
         state.check()
 
         self.assertEqual(dir(state.track), ["frame1", "frame2", "frame_ptr"])

--- a/tests/test_offsetptr.cpp
+++ b/tests/test_offsetptr.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+
+#include <structstore/structstore.hpp>
+
+namespace stst = structstore;
+
+TEST(StructStoreTestOffsetPtr, basic) {
+    int foo = 42;
+    stst::OffsetPtr<int> foo_ptr = &foo;
+    EXPECT_TRUE(foo_ptr);
+    EXPECT_EQ(foo_ptr.get(), &foo);
+    EXPECT_EQ((foo_ptr = nullptr).get(), nullptr);
+    EXPECT_EQ((foo_ptr = &foo).get(), &foo);
+    EXPECT_EQ(*foo_ptr, foo);
+    EXPECT_EQ((foo_ptr + 1).get(), &foo + 1);
+    EXPECT_EQ((foo_ptr - 1).get(), &foo - 1);
+    EXPECT_EQ((++foo_ptr).get(), &foo + 1);
+    EXPECT_EQ(foo_ptr.get(), &foo + 1);
+    EXPECT_EQ((--foo_ptr).get(), &foo);
+    EXPECT_EQ(foo_ptr.get(), &foo);
+    EXPECT_EQ((foo_ptr + 1) - foo_ptr, 1);
+    EXPECT_EQ(foo_ptr - (foo_ptr - 1), 1);
+
+    stst::OffsetPtr<int> nil_ptr;
+    EXPECT_FALSE(nil_ptr);
+    nil_ptr = nullptr;
+    EXPECT_FALSE(nil_ptr);
+}
+
+TEST(StructStoreTestOffsetPtr, string) {
+    std::string str = "foo";
+    using offset_string = std::basic_string<char, std::char_traits<char>, stst::StlAllocator<char>>;
+    offset_string str_{stst::StlAllocator<char>{stst::static_alloc}};
+    str_ = str;
+}
+
+TEST(StructStoreTestOffsetPtr, containers) {
+    std::vector<int, stst::StlAllocator<int>> v{stst::StlAllocator<char>{stst::static_alloc}};
+    v.reserve(10);
+    v.push_back(10);
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_offsetptr.cpp
+++ b/tests/test_offsetptr.cpp
@@ -13,7 +13,6 @@ TEST(StructStoreTestOffsetPtr, basic) {
     EXPECT_EQ((foo_ptr = &foo).get(), &foo);
     EXPECT_EQ(*foo_ptr, foo);
     EXPECT_EQ((foo_ptr + 1).get(), &foo + 1);
-    EXPECT_EQ((foo_ptr - 1).get(), &foo - 1);
     EXPECT_EQ((++foo_ptr).get(), &foo + 1);
     EXPECT_EQ(foo_ptr.get(), &foo + 1);
     EXPECT_EQ((--foo_ptr).get(), &foo);

--- a/tests/test_pickle_0.py
+++ b/tests/test_pickle_0.py
@@ -17,7 +17,7 @@ class TestPickle0(unittest.TestCase):
         state.lst = [1, 2, 3, 5, 8]
         state.tuple = (0.0, 0.0)
         state.check()
-        
+
         data = pickle.dumps(state)
         state2 = pickle.loads(data)
         print(state2)

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -11,7 +11,7 @@ TEST(StructStoreTestUtils, callstack) {
     std::string what;
     try {
         stst::Callstack::warn_with_trace("inner warning");
-        stst::Callstack::throw_with_trace<std::runtime_error>("inner error");
+        stst::Callstack::throw_with_trace("inner error");
     } catch (const std::runtime_error& e) { what = e.what(); }
 #ifndef NDEBUG
     EXPECT_EQ(what, "first: second: inner error");

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -13,7 +13,11 @@ TEST(StructStoreTestUtils, callstack) {
         stst::Callstack::warn_with_trace("inner warning");
         stst::Callstack::throw_with_trace<std::runtime_error>("inner error");
     } catch (const std::runtime_error& e) { what = e.what(); }
+#ifndef NDEBUG
     EXPECT_EQ(what, "first: second: inner error");
+#else
+    EXPECT_EQ(what, "inner error");
+#endif
 }
 
 TEST(StructStoreTestUtils, logging) {

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+
+#include <structstore/structstore.hpp>
+
+namespace stst = structstore;
+
+TEST(StructStoreTestUtils, callstack) {
+    stst::CallstackEntry entry0{"first"};
+    stst::CallstackEntry entry1{"second"};
+    { stst::CallstackEntry entry2{"third"}; }
+    std::string what;
+    try {
+        stst::Callstack::warn_with_trace("inner warning");
+        stst::Callstack::throw_with_trace<std::runtime_error>("inner error");
+    } catch (const std::runtime_error& e) { what = e.what(); }
+    EXPECT_EQ(what, "first: second: inner error");
+}
+
+TEST(StructStoreTestUtils, logging) {
+    STST_LOG_WARN() << "test warning";
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- ported everything to offset pointers to make the whole shared mem relocatable and remove the need of MAP_FIXED_NOREPLACE
- use ankerl::unordered_dense with fancy pointer support
- use 32bit offset pointers where possible to save space, as all data is in a contiguous memory block anyway
- introduced FieldRef to uniformly reference field data
- improved CMake config and CI tests